### PR TITLE
Stories/130310737 pump history into hmis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ end
 
 group :development, :test do
   gem 'pry-rails'
+  gem 'pry-byebug'
   gem 'foreman'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       momentjs-rails (>= 2.8.1)
     brakeman (3.3.2)
     builder (3.2.2)
+    byebug (9.0.6)
     capistrano (3.8.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -229,6 +230,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     puma (3.8.2)
@@ -389,6 +393,7 @@ DEPENDENCIES
   paper_trail
   paranoia (~> 2.0)
   pg
+  pry-byebug
   pry-rails
   puma
   quiet_assets
@@ -412,4 +417,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/app/models/hmis/base.rb
+++ b/app/models/hmis/base.rb
@@ -1,0 +1,6 @@
+module Hmis
+  class Base < ActiveRecord::Base
+    self.abstract_class = true
+    establish_connection "#{Rails.env}_warehouse".parameterize.underscore.to_sym
+  end
+end

--- a/app/models/hmis/build_report.rb
+++ b/app/models/hmis/build_report.rb
@@ -1,0 +1,66 @@
+module Hmis
+  class BuildReport
+    def run!
+      # we just flush the whole damned thing every time
+      Hmis::Report.delete_all
+      at = MatchDecisions::Base.arel_table
+      ::Client.joins( :project_client, client_opportunity_matches: :decisions ).preload(
+        :project_client,
+        {
+          client_opportunity_matches: {
+            decisions: %i[
+              decline_reason
+              not_working_with_client_reason
+              administrative_cancel_reason
+            ]
+          }
+        }
+      ).where( at[:status].not_eq nil ).distinct.find_each do |client|
+        client_id = client.project_client.id_in_data_source
+        client.client_opportunity_matches.each do |match|
+          # similar to match.current_decision, but more efficient given that we've preloaded all the decisions
+          decisions = match.decisions.select(&:status).sort_by(&:created_at)
+          next if decisions.empty?
+          current_decision = decisions.last
+          previous_updated_at = nil
+          decisions.each_with_index do |decision, idx|
+            if previous_updated_at
+              elapsed_days = ( decision.updated_at.to_date - previous_updated_at.to_date ).to_i
+            end
+            Hmis::Report.create!(
+              client_id: client_id,
+              match_id: match.id,
+              decision_id: decision.id,
+              decision_order: idx,
+              match_step: decision.step_name,
+              decision_status: current_decision.label,
+              current_step: decision == current_decision,
+              decline_reason: explain( decision, :decline_reason ),
+              not_working_with_client_reason: explain( decision, :not_working_with_client_reason ),
+              administrative_cancel_reason: explain( decision, :administrative_cancel_reason ),
+              active_match: match.active?,
+              created_at: decision.created_at,
+              updated_at: decision.updated_at,
+              elapsed_days: elapsed_days.to_i,
+              client_last_seen_date: decision.client_last_seen_date,
+              criminal_hearing_date: decision.criminal_hearing_date,
+              client_spoken_with_services_agency: decision.client_spoken_with_services_agency,
+              cori_release_form_submitted: decision.cori_release_form_submitted
+            )
+            previous_updated_at = decision.updated_at
+          end
+        end
+      end
+    end
+
+    def explain(decision, reason)
+      if r = decision.send(reason)
+        explanation = r.name
+        if r.other?
+          explanation = "#{explanation}: #{ decision.send "#{reason}_other_explanation" }"
+        end
+        explanation
+      end
+    end
+  end
+end

--- a/app/models/hmis/report.rb
+++ b/app/models/hmis/report.rb
@@ -1,0 +1,6 @@
+# for writing latest state of matches X decisions into HMIS database
+module Hmis
+  class Report < Base
+    self.table_name = 'cas_reports'
+  end
+end

--- a/lib/tasks/hmis.rake
+++ b/lib/tasks/hmis.rake
@@ -1,0 +1,10 @@
+namespace :hmis do
+  
+  desc "pump the latest client matches and decisions into the HMIS database"
+  task report: [:environment, "log:info_to_stdout"] do
+    Hmis::BuildReport.new.run!
+  end
+
+end
+
+


### PR DESCRIPTION
So I added pry-byebug for the sake of debugging -- it didn't seem there was any debugger yet in this project. The main thing, though, is the task code which populates the report table. See if that seems sane, please.

One thing I had to change from our discussion is that I filtered out "non-initialized" decisions, where these are decisions with nil statuses. It seemed there were a lot of these, but a match only has a current decision, according to the `current_decision` method, if it has initialized decisions, and these are decisions with some status. I figured maybe only initialized decisions were relevant, so I went ahead and filtered out all rows not corresponding to initialized decisions.

This isn't done, but I need to work on something else and hoped you'd have a look at the logic. The main thing that remains is to display the history on the HMIS side, which in principle is just a matter of choosing and arranging the data this code creates.