### PR TITLE
Stories/notes for all on matches

### DIFF
--- a/app/controllers/match_notes_controller.rb
+++ b/app/controllers/match_notes_controller.rb
@@ -39,7 +39,7 @@ class MatchNotesController < ApplicationController
   end
   
   def destroy
-    unless @match.can_create_administrative_note?(current_contact)
+    unless @match_note.note_editable_by?(current_contact)
       flash[:error] = 'You do not have permission to delete this note'
       redirect_to success_path and return
     end

--- a/app/controllers/match_notes_controller.rb
+++ b/app/controllers/match_notes_controller.rb
@@ -14,7 +14,9 @@ class MatchNotesController < ApplicationController
   end
   
   def create
-    @match_note.assign_attributes match_note_params
+    mn_params = match_note_params
+    mn_params.delete(:admin_note) unless @match.can_create_administrative_note?(current_contact)
+    @match_note.assign_attributes mn_params
     @match_note.contact = current_contact
     if @match_note.save
       redirect_to success_path
@@ -27,7 +29,9 @@ class MatchNotesController < ApplicationController
   end
   
   def update
-    if @match_note.update match_note_params
+    mn_params = match_note_params
+    mn_params.delete(:admin_note) unless @match.can_create_administrative_note?(current_contact)
+    if @match_note.update mn_params
       redirect_to success_path
     else
       render :edit
@@ -35,6 +39,10 @@ class MatchNotesController < ApplicationController
   end
   
   def destroy
+    unless @match.can_create_administrative_note?(current_contact)
+      flash[:error] = 'You do not have permission to delete this note'
+      redirect_to success_path and return
+    end
     @match_note.note = nil
     @match_note.remove_note!
     redirect_to success_path

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -301,7 +301,7 @@ class ClientOpportunityMatch < ActiveRecord::Base
   end
 
   def can_create_administrative_note? contact
-    contact && (contact.user && (contact.user.can_approve_matches? || contact.user.can_reject_matches?))
+    contact.present? && (contact.user.present? && (contact.user.can_approve_matches? || contact.user.can_reject_matches?))
   end
 
   def match_contacts

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -297,11 +297,11 @@ class ClientOpportunityMatch < ActiveRecord::Base
   end
 
   def can_create_overall_note? contact
-    can_create_administrative_note?(contact) || contact.user.can_create_overall_note?
+    can_create_administrative_note?(contact) || contact&.user&.can_create_overall_note?
   end
 
   def can_create_administrative_note? contact
-    contact && (contact.user && contact.user.can_approve_matches? || contact.user.can_reject_matches?)
+    contact && (contact.user && (contact.user.can_approve_matches? || contact.user.can_reject_matches?))
   end
 
   def match_contacts

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -297,6 +297,10 @@ class ClientOpportunityMatch < ActiveRecord::Base
   end
 
   def can_create_overall_note? contact
+    can_create_administrative_note?(contact) || contact.user.can_create_overall_note?
+  end
+
+  def can_create_administrative_note? contact
     contact && (contact.user && contact.user.can_approve_matches? || contact.user.can_reject_matches?)
   end
 

--- a/app/models/match_events/base.rb
+++ b/app/models/match_events/base.rb
@@ -43,7 +43,7 @@ module MatchEvents
     end
     
     def note_editable_by? editing_contact
-      editing_contact && (contact == editing_contact || match.can_create_administrative_note?(editing_contact))
+      editing_contact.present? && (contact == editing_contact || match.can_create_administrative_note?(editing_contact))
     end
     
     def remove_note!

--- a/app/models/match_events/base.rb
+++ b/app/models/match_events/base.rb
@@ -43,8 +43,7 @@ module MatchEvents
     end
     
     def note_editable_by? editing_contact
-      editing_contact &&
-      contact == editing_contact 
+      editing_contact && (contact == editing_contact || match.can_create_administrative_note?(editing_contact))
     end
     
     def remove_note!

--- a/app/models/match_events/note.rb
+++ b/app/models/match_events/note.rb
@@ -20,7 +20,7 @@ module MatchEvents
     end
 
     def show_note?(current_contact)
-      note.present? && (! admin_note || match.can_create_overall_note?(current_contact))
+      note.present? && (! admin_note || match.can_create_administrative_note?(current_contact))
     end
     
   end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -59,6 +59,7 @@ class Role < ActiveRecord::Base
       :can_edit_translations,
       :can_view_vspdats,
       :can_manage_config,
+      :can_create_overall_note,
     ]
   end
 

--- a/app/views/match_notes/_form.haml
+++ b/app/views/match_notes/_form.haml
@@ -1,4 +1,5 @@
 = simple_form_for @match_note, url: submit_url, as: :match_note, html: {data: {submits_to_pjax_modal: true}} do |form|
   = form.input :note, as: :text, input_html: {rows: 4}, label: false
-  = form.input :admin_note, label: 'Administrative note?', hint: 'If checked, this note will only be visible to users who create notes like this one.  Generally this permission is only given to administrators.'
+  - if @match.can_create_administrative_note?(access_context.current_contact)
+    = form.input :admin_note, label: 'Administrative note?', hint: 'If checked, this note will only be visible to users who create notes like this one.  Generally this permission is only given to administrators.'
   = form.submit "Save", class: 'btn btn-primary'

--- a/app/views/matches/_current_step_info.haml
+++ b/app/views/matches/_current_step_info.haml
@@ -19,10 +19,10 @@
     - else
       %p This match is not active
   .col-sm-3
-    - if @match.can_create_overall_note? current_contact
+    - if @match.can_create_overall_note?(access_context.current_contact)
       .pull-right
         .btn-label.btn-label__primary
-          = _('DND')
+          &nbsp;
         = link_to new_match_note_path(@match, match_note_referrer_params), class: 'btn btn-primary', data: {loads_in_pjax_modal: true} do
           %span.icon-plus
           Add Note

--- a/db/migrate/20171122203909_add_match_note_permission.rb
+++ b/db/migrate/20171122203909_add_match_note_permission.rb
@@ -1,0 +1,9 @@
+class AddMatchNotePermission < ActiveRecord::Migration
+  def up
+    Role.ensure_permissions_exist
+  end
+  
+  def down
+    remove_column :roles, :can_create_overall_note, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116160451) do
+ActiveRecord::Schema.define(version: 20171122203909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -693,6 +693,7 @@ ActiveRecord::Schema.define(version: 20171116160451) do
     t.boolean  "can_edit_translations",               default: false
     t.boolean  "can_view_vspdats",                    default: false
     t.boolean  "can_manage_config",                   default: false
+    t.boolean  "can_create_overall_note",             default: false
   end
 
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree

--- a/spec/factories/match_events/notes.rb
+++ b/spec/factories/match_events/notes.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :match_note, class: 'MatchEvents::Note' do
+    note 'A note'
+    admin_note false
+  end
+  factory :admin_note, class: 'MatchEvents::Note' do
+    note 'A note'
+    admin_note true
+  end
+end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -48,5 +48,12 @@ FactoryGirl.define do
     can_become_other_users true 
     can_edit_translations true
     can_view_vspdats true
+    can_create_overall_note true
+  end
+
+  factory :shelter_role, class: 'Role' do
+    name "shelter"
+    can_participate_in_matches true
+    can_create_overall_note true
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,35 @@
 FactoryGirl.define do
-  factory :user do
-    first_name 'Peter'
-    last_name 'Clark'
-    email 'peter@greenriver.com'
+  factory :user, class: 'User' do
+    first_name 'User'
+    last_name 'One'
+    email 'user_one@example.com'
+    password 'abcd1234'
+    password_confirmation 'abcd1234'
+    confirmed_at Date.yesterday
+    contact
+  end
+  factory :user_two, class: 'User' do
+    first_name 'User'
+    last_name 'Two'
+    email 'user_two@example.com'
+    password 'abcd1234'
+    password_confirmation 'abcd1234'
+    confirmed_at Date.yesterday
+    contact
+  end
+  factory :user_three, class: 'User' do
+    first_name 'User'
+    last_name 'Three'
+    email 'user_three@example.com'
+    password 'abcd1234'
+    password_confirmation 'abcd1234'
+    confirmed_at Date.yesterday
+    contact
+  end
+  factory :user_four, class: 'User' do
+    first_name 'User'
+    last_name 'Four'
+    email 'user_four@example.com'
     password 'abcd1234'
     password_confirmation 'abcd1234'
     confirmed_at Date.yesterday

--- a/spec/models/match_events/note_spec.rb
+++ b/spec/models/match_events/note_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe MatchEvents::Note, type: :model do
+
+  let(:shelter) { create :user }
+  let(:admin) { create :user_two }
+  let(:no_roles) { create :user_three }
+  let(:admin_role) {create :admin_role }
+  let(:shelter_role) {create :shelter_role }
+  let(:match) { create :client_opportunity_match }
+  let(:admin_note) { create :admin_note }
+  let(:match_note) { create :match_note }
+
+  describe 'Note access: ' do
+    before do
+      admin.roles << admin_role
+      match.dnd_staff_contacts << admin.contact
+      match.shelter_agency_contacts << shelter.contact
+      match.client_contacts << no_roles.contact
+      admin_note.match = match
+      admin_note.contact = admin.contact
+      match_note.match = match
+      match_note.contact = admin.contact
+    end
+    context 'If admin creates the note,' do
+      it 'admin should be able to edit it' do
+        expect( match_note.note_editable_by?(admin.contact) ).to be(true)
+      end
+      it 'shelter should not be able to edit it' do
+        expect( match_note.note_editable_by?(shelter.contact) ).to be_falsy
+      end
+      it 'admin should be able to edit administrative note' do
+        expect( admin_note.note_editable_by?(admin.contact) ).to be(true)
+      end
+      it 'admin should be able to see administrative note' do
+        expect( admin_note.show_note?(admin.contact) ).to be(true)
+      end
+      it 'shelter should not be able to edit administrative note' do
+        expect( admin_note.note_editable_by?(shelter.contact) ).to be_falsy
+      end
+      it 'shelter should not be able to see administrative note' do
+        expect( admin_note.show_note?(shelter.contact) ).to be_falsy
+      end
+    end
+    context 'If shelter creates the note,' do
+      it 'admin should be able to edit it' do
+        match_note.update(contact_id: shelter.contact.id)
+        expect( match_note.note_editable_by?(admin.contact) ).to be(true)
+      end
+      it 'shelter should be able to edit it' do
+        match_note.update(contact_id: shelter.contact.id)
+        expect( match_note.note_editable_by?(shelter.contact) ).to be(true)
+      end
+      it 'client contact should not be able to edit it' do
+        match_note.update(contact_id: shelter.contact.id)
+        expect( match_note.note_editable_by?(no_roles.contact) ).to be_falsy
+      end
+      it 'client contact should be able to see it' do
+        match_note.update(contact_id: shelter.contact.id)
+        expect( match_note.show_note?(no_roles.contact) ).to be(true)
+      end
+    end
+
+    it 'Admin should not be able to create an administrative note' do
+      expect( match.can_create_administrative_note? admin.contact ).to be(true)
+    end
+    it 'Shelter should not be able to create an administrative note' do
+      match_note.update(contact_id: shelter.contact.id)
+      expect( match.can_create_administrative_note? shelter.contact ).to be_falsy
+    end
+    
+  end
+end


### PR DESCRIPTION
This sets up a permission for adding overall match notes for any role.  The idea is that any contact can leave a note on the match without submitting a decision.  Only some roles can leave administrative notes and those notes are only visible to the roles that can leave them.  The administrative note permission is governed by the ability to see/edit all clients, which is an administrative permission.

Users should be able to see, edit and delete their own notes, administrators (those with the edit all clients permission) should be able to see edit and delete any note, including the administrative ones.