### PR TITLE
Add additional attributes to units

### DIFF
--- a/app/controllers/unit_for_building_controller.rb
+++ b/app/controllers/unit_for_building_controller.rb
@@ -2,7 +2,7 @@ class UnitForBuildingController < ApplicationController
   before_action :authenticate_user!
   before_action :require_can_add_vacancies!
   include PjaxModalController
-  
+
   def new
     @buildings = building_scope
     @units = []
@@ -43,9 +43,12 @@ class UnitForBuildingController < ApplicationController
     def building_scope
       Building.all
     end
-    
+
     # Only allow a trusted parameter "white list" through.
     def unit_params
-      params.require(:unit_for_building).permit(:name, :available, :building_id)
+      params.require(:unit_for_building).permit(:name, :available, :building_id,
+        :ground_floor, :wheelchair_accessible, :occupancy, :number_of_bedrooms,
+        :target_population
+      )
     end
 end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -112,7 +112,10 @@ class UnitsController < ApplicationController
     end
     # Only allow a trusted parameter "white list" through.
     def unit_params
-      params.require(:unit).permit(:name, :available, :building_id)
+      params.require(:unit).permit(:name, :available, :building_id,
+        :ground_floor, :wheelchair_accessible, :occupancy, :number_of_bedrooms,
+        :target_population
+      )
     end
 
     def sort_column

--- a/app/models/opportunity_details/via_voucher.rb
+++ b/app/models/opportunity_details/via_voucher.rb
@@ -7,7 +7,43 @@ module OpportunityDetails
     def unit_name
       voucher.unit.try :name
     end
-    
+
+    def unit_on_ground_floor?
+      return nil unless voucher.unit
+      voucher.unit.ground_floor? ? "Yes" : "No"
+    end
+
+    def unit_is_wheelchair_accessible?
+      return nil unless voucher.unit
+      voucher.unit.wheelchair_accessible? ? "Yes" : "No"
+    end
+
+    def unit_occupancy
+      return nil unless voucher.unit
+      voucher.unit.occupancy
+    end
+
+    def unit_bedrooms
+      return nil unless voucher.unit
+      voucher.unit.number_of_bedrooms
+    end
+
+    def unit_target_population
+      return nil unless voucher.unit
+      voucher.unit.target_population.titleize
+    end
+
+    def unit_details
+      return nil unless voucher.unit
+      [
+        "Ground Floor: #{unit_on_ground_floor?}",
+        "Wheelchair Accessible: #{unit_is_wheelchair_accessible?}",
+        "Occupancy: #{unit_occupancy}",
+        "Bedrooms: #{unit_bedrooms}",
+        "Target Population: #{unit_target_population}",
+      ]
+    end
+
     def building_name
       voucher.building.try :name
     end
@@ -21,11 +57,11 @@ module OpportunityDetails
       return nil if voucher.building.nil?
       voucher.building.map_link
     end
-    
+
     def program_name
       voucher.sub_program&.program&.name
     end
-    
+
     def sub_program_name
       voucher.sub_program&.name
     end
@@ -37,7 +73,7 @@ module OpportunityDetails
     def subgrantee_name
       voucher.building&.subgrantee&.name
     end
-    
+
     def funding_source_name
       voucher.sub_program&.program&.funding_source&.name
     end
@@ -64,11 +100,11 @@ module OpportunityDetails
       # TODO implement me
       []
     end
-    
+
     def rules_with_source
       # TODO implement me
       []
     end
-    
+
   end
 end

--- a/app/models/rules/requiring_ground_floor.rb
+++ b/app/models/rules/requiring_ground_floor.rb
@@ -1,0 +1,14 @@
+class Rules::RequiringGroundFloor < Rule
+  def clients_that_fit(scope, requirement)
+    if Client.column_names.include?(:requires_ground_floor.to_s)
+      if requirement.positive
+        where = "requires_ground_floor IS TRUE"
+      else
+        where = "requires_ground_floor IS FALSE"
+      end
+      scope.where(where)
+    else
+      raise RuleDatabaseStructureMissing.new("clients.requires_ground_floor missing. Cannot check clients against #{self.class}.")
+    end
+  end
+end

--- a/app/models/rules/requiring_wheelchair_accessibility.rb
+++ b/app/models/rules/requiring_wheelchair_accessibility.rb
@@ -1,0 +1,14 @@
+class Rules::RequiringWheelchairAccessibility < Rule
+  def clients_that_fit(scope, requirement)
+    if Client.column_names.include?(:requires_wheelchair_accessibility.to_s)
+      if requirement.positive
+        where = "requires_wheelchair_accessibility IS TRUE"
+      else
+        where = "requires_wheelchair_accessibility IS FALSE"
+      end
+      scope.where(where)
+    else
+      raise RuleDatabaseStructureMissing.new("clients.requires_wheelchair_accessibility missing. Cannot check clients against #{self.class}.")
+    end
+  end
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -10,12 +10,17 @@ class Unit < ActiveRecord::Base
   has_many :opportunities, inverse_of: :unit
   has_many :vouchers, inverse_of: :unit
   has_one :active_voucher, -> { where available: true}, class_name: 'Voucher'
-  has_one :opportunity, through: :active_voucher 
+  has_one :opportunity, through: :active_voucher
 
   delegate :active_match, to: :active_voucher
   delegate :program, to: :active_voucher
 
   validates :name, presence: true
+  validates_inclusion_of :occupancy, :in => 1..10
+
+  TARGET_POPULATION_TYPES = %w(family individual youth)
+
+  validates :target_population, inclusion: { in: TARGET_POPULATION_TYPES }, allow_blank: true
 
   def hmis_managed?
     return true if id_in_data_source
@@ -46,5 +51,9 @@ class Unit < ActiveRecord::Base
 
   def self.associations_adding_services
     [:building]
+  end
+
+  def self.target_population_select_array
+    self::TARGET_POPULATION_TYPES.map { |type| [type.titleize, type] }
   end
 end

--- a/app/views/matches/_building_details.haml
+++ b/app/views/matches/_building_details.haml
@@ -1,7 +1,7 @@
 %h3.detail-box--label= "#{Building.model_name.human}"
 .detail-box--value
   - unless match.opportunity_details.building_name == match.opportunity_details.building_address.join(' ')
-    = match.opportunity_details.building_name 
+    = match.opportunity_details.building_name
     %br
   - match.opportunity_details.building_address.each do |line|
     - if match.opportunity_details.building_map_link
@@ -11,3 +11,19 @@
     %br
 %h3.detail-box--label Unit
 .detail-box--value= match.opportunity_details.unit_name
+%h3.detail-box--label Unit Details
+.detail-box--value
+  - match.opportunity_details.unit_details.each do |line|
+    = line
+    %br
+
+-# %h3.detail-box--label Ground Floor
+  .detail-box--value= match.opportunity_details.unit_on_ground_floor?
+  %h3.detail-box--label Wheelchair Accessible
+  .detail-box--value= match.opportunity_details.unit_is_wheelchair_accessible?
+  %h3.detail-box--label Unit Occupancy
+  .detail-box--value= match.opportunity_details.unit_occupancy
+  %h3.detail-box--label Number of Bedrooms
+  .detail-box--value= match.opportunity_details.unit_bedrooms
+  %h3.detail-box--label Target Population
+  .detail-box--value= match.opportunity_details.unit_target_population

--- a/app/views/matches/_building_details.haml
+++ b/app/views/matches/_building_details.haml
@@ -16,14 +16,3 @@
   - match.opportunity_details.unit_details.each do |line|
     = line
     %br
-
--# %h3.detail-box--label Ground Floor
-  .detail-box--value= match.opportunity_details.unit_on_ground_floor?
-  %h3.detail-box--label Wheelchair Accessible
-  .detail-box--value= match.opportunity_details.unit_is_wheelchair_accessible?
-  %h3.detail-box--label Unit Occupancy
-  .detail-box--value= match.opportunity_details.unit_occupancy
-  %h3.detail-box--label Number of Bedrooms
-  .detail-box--value= match.opportunity_details.unit_bedrooms
-  %h3.detail-box--label Target Population
-  .detail-box--value= match.opportunity_details.unit_target_population

--- a/app/views/unit_for_building/_edit_form.html.haml
+++ b/app/views/unit_for_building/_edit_form.html.haml
@@ -3,7 +3,12 @@
   .form-inputs.margin-top-02
     = f.input :available, as: :boolean
     = f.input :name, label: "#{Unit.model_name.human} name"
-        
+    = f.input :occupancy, collection: 1..10, include_blank: false
+    = f.input :number_of_bedrooms, collection: 1..5
+    = f.input :target_population, collection: Unit.target_population_select_array
+    = f.input :ground_floor, as: :radio_buttons
+    = f.input :wheelchair_accessible, as: :radio_buttons
+
   .form-actions
     = f.button :submit, value: "Update #{Unit.model_name.human}"
 

--- a/app/views/unit_for_building/_form.html.haml
+++ b/app/views/unit_for_building/_form.html.haml
@@ -4,9 +4,14 @@
     = f.input :building_id, collection: @buildings, label: "Where is this unit located?", selected: params[:building_id], class: 'has-dependent'
     = f.input :available, as: :hidden, input_html: {value: true}
     =# debug @buildings
-    
+
     = f.input :name, label: "#{Unit.model_name.human} name"
-        
+    = f.input :occupancy, collection: 1..10, include_blank: false
+    = f.input :number_of_bedrooms, collection: 1..5
+    = f.input :target_population, collection: Unit.target_population_select_array
+    = f.input :ground_floor, as: :radio_buttons
+    = f.input :wheelchair_accessible, as: :radio_buttons
+
   .form-actions
     = f.button :submit, value: "Add #{Unit.model_name.human}"
 

--- a/app/views/units/_form.html.haml
+++ b/app/views/units/_form.html.haml
@@ -5,14 +5,18 @@
   .form-inputs.margin-top-02
     - if @unit.in_use? && @unit.active_voucher.present? && @unit.active_match.present?
       - disabled = true
-      %p 
-        This unit is involved in a 
+      %p
+        This unit is involved in a
         = "#{link_to 'match', match_path(@unit.active_match)}, it's availability cannot be adjusted, nor can it be moved to another site.".html_safe
     %label.margin-bottom-00 Is the Unit Available?
     = f.input :available, disabled: disabled
     = f.association :building, label_method: :name, disabled: disabled, label: "#{Building.model_name.human}"
     = f.input :name
-        
+    = f.input :occupancy, collection: 1..10, include_blank: false
+    = f.input :number_of_bedrooms, collection: 1..5
+    = f.input :target_population, collection: Unit.target_population_select_array
+    = f.input :ground_floor, as: :radio_buttons
+    = f.input :wheelchair_accessible, as: :radio_buttons
+
   .form-actions
     = f.button :submit
-

--- a/db/migrate/20180528160945_add_attributes_to_units.rb
+++ b/db/migrate/20180528160945_add_attributes_to_units.rb
@@ -1,0 +1,9 @@
+class AddAttributesToUnits < ActiveRecord::Migration
+  def change
+    add_column :units, :ground_floor, :boolean
+    add_column :units, :wheelchair_accessible, :boolean
+    add_column :units, :occupancy, :integer, default: 1
+    add_column :units, :number_of_bedrooms, :integer
+    add_column :units, :target_population, :string
+  end
+end

--- a/db/migrate/20180528194112_add_unit_requirements_to_project_clients.rb
+++ b/db/migrate/20180528194112_add_unit_requirements_to_project_clients.rb
@@ -1,0 +1,7 @@
+class AddUnitRequirementsToProjectClients < ActiveRecord::Migration
+  def change
+    add_column :project_clients, :requires_ground_floor, :boolean, default: false, null: false
+    add_column :project_clients, :requires_wheelchair_accessibility, :boolean, default: false, null: false
+    add_column :project_clients, :required_number_of_bedrooms, :integer, default: 1, null: false
+  end
+end

--- a/db/migrate/20180528194118_add_unit_requirements_to_clients.rb
+++ b/db/migrate/20180528194118_add_unit_requirements_to_clients.rb
@@ -1,0 +1,7 @@
+class AddUnitRequirementsToClients < ActiveRecord::Migration
+  def change
+    add_column :clients, :requires_ground_floor, :boolean, default: false, null: false
+    add_column :clients, :requires_wheelchair_accessibility, :boolean, default: false, null: false
+    add_column :clients, :required_number_of_bedrooms, :integer, default: 1, null: false
+  end
+end

--- a/db/rules.csv
+++ b/db/rules.csv
@@ -54,3 +54,4 @@ VispdatScoreFourToSeven,VI-SPDAT score of 4 to 7,have
 VispdatScoreEightOrMore,VI-SPDAT score of 8 or more,have
 EnrolledInHmisProject,Enrolled in specified HMIS Project,be
 ActiveInCohort,Active in specified Cohort,be
+RequiringWheelchairAccessibility,Requiring wheelchair accessibility,be

--- a/db/rules.csv
+++ b/db/rules.csv
@@ -55,3 +55,4 @@ VispdatScoreEightOrMore,VI-SPDAT score of 8 or more,have
 EnrolledInHmisProject,Enrolled in specified HMIS Project,be
 ActiveInCohort,Active in specified Cohort,be
 RequiringWheelchairAccessibility,Requiring wheelchair accessibility,be
+RequiringGroundFloor,Requiring ground floor,be

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180528160945) do
+ActiveRecord::Schema.define(version: 20180528194118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -200,6 +200,9 @@ ActiveRecord::Schema.define(version: 20180528160945) do
     t.jsonb    "active_cohort_ids"
     t.string   "client_identifier"
     t.integer  "assessment_score",                                  default: 0,     null: false
+    t.boolean  "requires_ground_floor",                             default: false, null: false
+    t.boolean  "requires_wheelchair_accessibility",                 default: false, null: false
+    t.integer  "required_number_of_bedrooms",                       default: 1,     null: false
   end
 
   add_index "clients", ["deleted_at"], name: "index_clients_on_deleted_at", using: :btree
@@ -677,6 +680,9 @@ ActiveRecord::Schema.define(version: 20180528160945) do
     t.string   "client_identifier"
     t.integer  "vispdat_priority_score",                 default: 0
     t.integer  "assessment_score",                       default: 0,     null: false
+    t.boolean  "requires_ground_floor",                  default: false, null: false
+    t.boolean  "requires_wheelchair_accessibility",      default: false, null: false
+    t.integer  "required_number_of_bedrooms",            default: 1,     null: false
   end
 
   add_index "project_clients", ["calculated_chronic_homelessness"], name: "index_project_clients_on_calculated_chronic_homelessness", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180511081334) do
+ActiveRecord::Schema.define(version: 20180528160945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,7 +167,7 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.boolean  "disabling_condition",                               default: false
     t.datetime "release_of_information"
     t.date     "prevent_matching_until"
-    t.boolean  "dmh_eligible",                                      default: false
+    t.boolean  "dmh_eligible",                                      default: false, null: false
     t.boolean  "va_eligible",                                       default: false, null: false
     t.boolean  "hues_eligible",                                     default: false, null: false
     t.datetime "disability_verified_on"
@@ -192,8 +192,8 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.integer  "vispdat_priority_score",                            default: 0
     t.integer  "vispdat_length_homeless_in_days",                   default: 0,     null: false
     t.boolean  "cspech_eligible",                                   default: false
-    t.string   "alternate_names"
     t.date     "calculated_last_homeless_night"
+    t.string   "alternate_names"
     t.boolean  "congregate_housing",                                default: false
     t.boolean  "sober_housing",                                     default: false
     t.jsonb    "enrolled_project_ids"
@@ -649,7 +649,7 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.string   "workphone"
     t.string   "pager"
     t.string   "email"
-    t.boolean  "dmh_eligible",                           default: false
+    t.boolean  "dmh_eligible",                           default: false, null: false
     t.boolean  "va_eligible",                            default: false, null: false
     t.boolean  "hues_eligible",                          default: false, null: false
     t.datetime "disability_verified_on"
@@ -740,6 +740,7 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.boolean  "can_edit_all_clients",                    default: false
     t.boolean  "can_participate_in_matches",              default: false
     t.boolean  "can_view_all_matches",                    default: false
+    t.boolean  "can_view_own_closed_matches",             default: false
     t.boolean  "can_see_alternate_matches",               default: false
     t.boolean  "can_edit_match_contacts",                 default: false
     t.boolean  "can_approve_matches",                     default: false
@@ -750,6 +751,11 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.boolean  "can_edit_users",                          default: false
     t.boolean  "can_view_full_ssn",                       default: false
     t.boolean  "can_view_full_dob",                       default: false
+    t.boolean  "can_view_dmh_eligibility",                default: false
+    t.boolean  "can_view_va_eligibility",                 default: false
+    t.boolean  "can_view_hues_eligibility",               default: false
+    t.boolean  "can_view_hiv_positive_eligibility",       default: false
+    t.boolean  "can_view_client_confidentiality",         default: false
     t.boolean  "can_view_buildings",                      default: false
     t.boolean  "can_edit_buildings",                      default: false
     t.boolean  "can_view_funding_sources",                default: false
@@ -774,21 +780,15 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.boolean  "can_edit_available_services",             default: false
     t.boolean  "can_assign_services",                     default: false
     t.boolean  "can_assign_requirements",                 default: false
-    t.boolean  "can_view_dmh_eligibility",                default: false
-    t.boolean  "can_view_va_eligibility",                 default: false, null: false
-    t.boolean  "can_view_hues_eligibility",               default: false, null: false
     t.boolean  "can_become_other_users",                  default: false
-    t.boolean  "can_view_client_confidentiality",         default: false, null: false
-    t.boolean  "can_view_hiv_positive_eligibility",       default: false
-    t.boolean  "can_view_own_closed_matches",             default: false
     t.boolean  "can_edit_translations",                   default: false
     t.boolean  "can_view_vspdats",                        default: false
     t.boolean  "can_manage_config",                       default: false
     t.boolean  "can_create_overall_note",                 default: false
+    t.boolean  "can_delete_client_notes",                 default: false
     t.boolean  "can_enter_deidentified_clients",          default: false
     t.boolean  "can_manage_deidentified_clients",         default: false
     t.boolean  "can_add_cohorts_to_deidentified_clients", default: false
-    t.boolean  "can_delete_client_notes",                 default: false
   end
 
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
@@ -945,12 +945,17 @@ ActiveRecord::Schema.define(version: 20180511081334) do
     t.integer  "adult_only"
     t.integer  "family"
     t.integer  "child_only"
-    t.integer  "building_id",                null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.integer  "building_id",                            null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.datetime "deleted_at"
     t.integer  "data_source_id"
     t.string   "data_source_id_column_name"
+    t.boolean  "ground_floor"
+    t.boolean  "wheelchair_accessible"
+    t.integer  "occupancy",                  default: 1
+    t.integer  "number_of_bedrooms"
+    t.string   "target_population"
   end
 
   add_index "units", ["building_id"], name: "index_units_on_building_id", using: :btree

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -47,7 +47,7 @@ FactoryGirl.define do
     name 'Physically disabling condition'
     verb 'have'
   end
-  factory :income_less_than_50_percent_ami, class: 'Rules::IncomeLessThanFiftyPercentAmi' do 
+  factory :income_less_than_50_percent_ami, class: 'Rules::IncomeLessThanFiftyPercentAmi' do
     name 'Less than 50% Area Median Income (Very Low Income)'
     verb 'have'
   end
@@ -74,5 +74,9 @@ FactoryGirl.define do
   factory :vispdat_more_than_8, class: 'Rules::VispdatScoreEightOrMore' do
     name 'VI-SPDAT score of 8 or more'
     verb 'have'
+  end
+  factory :requiring_wheelchair_accessibility, class: 'Rules::RequiringWheelchairAccessibility' do
+    name 'Requiring wheelchair accessibility'
+    verb 'be'
   end
 end

--- a/spec/factories/rules.rb
+++ b/spec/factories/rules.rb
@@ -79,4 +79,8 @@ FactoryGirl.define do
     name 'Requiring wheelchair accessibility'
     verb 'be'
   end
+  factory :requiring_ground_floor, class: 'Rules::RequiringGroundFloor' do
+    name 'Requiring ground floor'
+    verb 'be'
+  end
 end

--- a/spec/models/rules/requiring_ground_floor_spec.rb
+++ b/spec/models/rules/requiring_ground_floor_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Rules::RequiringGroundFloor, type: :model do
+
+  let!(:ground_floor_rule) { create :requiring_ground_floor }
+  let!(:clients_requiring_ground_floor) { create_list :client, 3, requires_ground_floor: true }
+  let!(:clients_not_requiring_ground_floor) { create_list :client, 2, requires_ground_floor: false }
+
+  let!(:positive) { create :requirement, rule: ground_floor_rule, positive: true }
+  let!(:negative) { create :requirement, rule: ground_floor_rule, positive: false }
+  let!(:clients_that_fit) { positive.clients_that_fit(Client.all) }
+  let!(:clients_that_dont_fit) { negative.clients_that_fit(Client.all) }
+
+  describe 'clients_that_fit RequiringGroundFloor' do
+
+    context 'when positive' do
+      it 'matches clients that require ground floor' do
+        expect(clients_that_fit.count).to eq 3
+      end
+      it 'contains clients requiring ground floor' do
+        expect(clients_that_fit.ids).to include *clients_requiring_ground_floor.map(&:id)
+      end
+      it 'does not contain clients not requiring ground floor' do
+        expect(clients_that_fit.ids).to_not include *clients_not_requiring_ground_floor.map(&:id)
+      end
+    end
+    context 'when negative' do
+      it 'matches clients that do not require ground floor' do
+        expect(clients_that_dont_fit.count).to eq 2
+      end
+      it 'contains clients not requiring ground floor' do
+        expect(clients_that_dont_fit.ids).to include *clients_not_requiring_ground_floor.map(&:id)
+      end
+      it 'does not contain clients requiring ground floor' do
+        expect(clients_that_dont_fit.ids).to_not include *clients_requiring_ground_floor.map(&:id)
+      end
+    end
+  end
+end

--- a/spec/models/rules/requiring_wheelchair_accessibility_spec.rb
+++ b/spec/models/rules/requiring_wheelchair_accessibility_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Rules::RequiringWheelchairAccessibility, type: :model do
+
+  let!(:wheelchair_accessibility_rule) { create :requiring_wheelchair_accessibility }
+  let!(:clients_requiring_accessibility) { create_list :client, 3, requires_wheelchair_accessibility: true }
+  let!(:clients_not_requiring_accessibility) { create_list :client, 2, requires_wheelchair_accessibility: false }
+
+  let!(:positive) { create :requirement, rule: wheelchair_accessibility_rule, positive: true }
+  let!(:negative) { create :requirement, rule: wheelchair_accessibility_rule, positive: false }
+  let!(:clients_that_fit) { positive.clients_that_fit(Client.all) }
+  let!(:clients_that_dont_fit) { negative.clients_that_fit(Client.all) }
+
+  describe 'clients_that_fit RequiringWheelchairAccessibility' do
+
+    context 'when positive' do
+      it 'matches clients that require wheelchair accessibility' do
+        expect(clients_that_fit.count).to eq 3
+      end
+      it 'contains clients requiring wheelchair accessibility' do
+        expect(clients_that_fit.ids).to include *clients_requiring_accessibility.map(&:id)
+      end
+      it 'does not contain clients not requiring wheelchair accessibility' do
+        expect(clients_that_fit.ids).to_not include *clients_not_requiring_accessibility.map(&:id)
+      end
+    end
+    context 'when negative' do
+      it 'matches clients that do not require wheelchair accessibility' do
+        expect( clients_that_dont_fit.count ).to eq 2
+      end
+      it 'contains clients not requiring wheelchair accessibility' do
+        expect( clients_that_dont_fit.ids ).to include *clients_not_requiring_accessibility.map(&:id)
+      end
+      it 'does not contain clients requiring wheelchair accessibility' do
+        expect( clients_that_dont_fit.ids ).to_not include *clients_requiring_accessibility.map(&:id)
+      end
+    end
+  end
+end

--- a/spec/models/rules/requiring_wheelchair_accessibility_spec.rb
+++ b/spec/models/rules/requiring_wheelchair_accessibility_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe Rules::RequiringWheelchairAccessibility, type: :model do
     end
     context 'when negative' do
       it 'matches clients that do not require wheelchair accessibility' do
-        expect( clients_that_dont_fit.count ).to eq 2
+        expect(clients_that_dont_fit.count).to eq 2
       end
       it 'contains clients not requiring wheelchair accessibility' do
-        expect( clients_that_dont_fit.ids ).to include *clients_not_requiring_accessibility.map(&:id)
+        expect(clients_that_dont_fit.ids).to include *clients_not_requiring_accessibility.map(&:id)
       end
       it 'does not contain clients requiring wheelchair accessibility' do
-        expect( clients_that_dont_fit.ids ).to_not include *clients_requiring_accessibility.map(&:id)
+        expect(clients_that_dont_fit.ids).to_not include *clients_requiring_accessibility.map(&:id)
       end
     end
   end


### PR DESCRIPTION
Adds the following attributes to ```Unit```
- ground_floor
- wheelchair_accessible
- occupancy
- number_of_bedrooms
- target_population

Exposes attributes to views, adds  supporting columns to ```ProjectClient``` and ```Client```, and adds rules for matching on ground_floor, wheelchair_accessible, and number_of_bedrooms.

PR for issue: https://github.com/greenriver/boston-cas/issues/13