### PR TITLE
Non-HMIS client updates

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -71,6 +71,7 @@ module Admin
           :last_name,
           :email,
           :receive_initial_notification,
+          :agency,
           role_ids: [],
           contact_attributes: [:id, :first_name, :last_name, :phone, :email, :role]
         )

--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -2,6 +2,7 @@ class DeidentifiedClientsController < ApplicationController
   before_action :require_can_enter_deidentified_clients!
   before_action :require_can_manage_deidentified_clients!, only: [:edit, :update, :destroy]
   before_action :load_deidentified_client, only: [:edit, :update, :destroy]
+  before_action :load_agencies, only: [:new, :edit]
 
   def index
     @deidentified_clients = deidentified_client_source.order(agency: :asc, last_name: :asc, first_name: :asc).page(params[:page]).per(25)
@@ -13,7 +14,7 @@ class DeidentifiedClientsController < ApplicationController
   end
 
   def new
-    @deidentified_client = deidentified_client_source.new
+    @deidentified_client = deidentified_client_source.new(agency: current_user.agency)
   end
 
   def edit
@@ -66,5 +67,9 @@ class DeidentifiedClientsController < ApplicationController
 
     def load_deidentified_client
       @deidentified_client = deidentified_client_source.find params[:id].to_i
+    end
+
+    def load_agencies
+      @available_agencies = User.distinct.pluck(:agency).compact
     end
 end

--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -30,7 +30,7 @@ class DeidentifiedClientsController < ApplicationController
   end
 
   def deidentified_client_source
-    DeidentifiedClient.visible_to(current_user)
+    DeidentifiedClient.deidentified.visible_to(current_user)
   end
 
   private

--- a/app/controllers/identified_clients_controller.rb
+++ b/app/controllers/identified_clients_controller.rb
@@ -5,7 +5,7 @@ class IdentifiedClientsController < DeidentifiedClientsController
 
   def create
     @deidentified_client = deidentified_client_source.create(clean_params(identified_client_params))
-    respond_with(@deidentified_client, location: deidentified_clients_path)
+    respond_with(@deidentified_client, location: identified_clients_path)
   end
 
   def new
@@ -17,7 +17,7 @@ class IdentifiedClientsController < DeidentifiedClientsController
 
   def update
     @deidentified_client.update(clean_params(identified_client_params))
-    respond_with(@deidentified_client, location: deidentified_clients_path)
+    respond_with(@deidentified_client, location: identified_clients_path)
   end
 
   def clean_params dirty_params
@@ -27,6 +27,11 @@ class IdentifiedClientsController < DeidentifiedClientsController
   end
 
   private
+
+    def deidentified_client_source
+      DeidentifiedClient.identified.visible_to(current_user)
+    end
+
     def identified_client_params
       params.require(:deidentified_client).permit(
         :client_identifier,

--- a/app/controllers/identified_clients_controller.rb
+++ b/app/controllers/identified_clients_controller.rb
@@ -1,15 +1,13 @@
 class IdentifiedClientsController < DeidentifiedClientsController
-  before_action :require_can_enter_deidentified_clients!
-  before_action :require_can_manage_deidentified_clients!, only: [:edit, :update, :destroy]
+  skip_before_action :require_can_enter_deidentified_clients!
+  skip_before_action :require_can_manage_deidentified_clients!
+  before_action :require_can_enter_identified_clients!
+  before_action :require_can_manage_identified_clients!, only: [:edit, :update, :destroy]
   before_action :load_deidentified_client, only: [:edit, :update]
 
   def create
     @deidentified_client = deidentified_client_source.create(clean_params(identified_client_params))
     respond_with(@deidentified_client, location: identified_clients_path)
-  end
-
-  def new
-    @deidentified_client = deidentified_client_source.new
   end
 
   def edit
@@ -49,6 +47,10 @@ class IdentifiedClientsController < DeidentifiedClientsController
         :income_maximization_assistance_requested,
         :pending_subsidized_housing_placement,
         :full_release_on_file,
+        :requires_wheelchair_accessibility,
+        :required_number_of_bedrooms,
+        :required_minimum_occupancy,
+        :requires_elevator_access,
         :active_cohort_ids => [],
       ).merge(identified: true)
     end

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -16,6 +16,14 @@ class DeidentifiedClient < ActiveRecord::Base
     all
   end
 
+  scope :identified, -> do
+    where(identified: true)
+  end
+
+  scope :deidentified, -> do
+    where(identified: false)
+  end
+
   def involved_in_match?
     client_opportunity_matches.exists?
   end

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -11,9 +11,15 @@ class DeidentifiedClient < ActiveRecord::Base
   has_paper_trail
   acts_as_paranoid
 
-  # TODO
   scope :visible_to, -> (user) do
-    all
+    if user.can_edit_all_clients?
+      all
+    else
+      where(
+        arel_table[:agency].eq(nil).
+        or(arel_table[:agency].eq(user.agency))
+      )
+    end
   end
 
   scope :identified, -> do
@@ -45,6 +51,12 @@ class DeidentifiedClient < ActiveRecord::Base
     project_client.rrh_desired = rrh_desired
     project_client.youth_rrh_desired = youth_rrh_desired
     project_client.rrh_assessment_contact_info = rrh_assessment_contact_info if income_maximization_assistance_requested
+
+    project_client.required_number_of_bedrooms = required_number_of_bedrooms
+    project_client.required_minimum_occupancy = required_minimum_occupancy
+    project_client.requires_wheelchair_accessibility = requires_wheelchair_accessibility
+    project_client.requires_elevator_access = requires_elevator_access
+
     project_client.housing_release_status = _('Full HAN Release') if full_release_on_file
 
     project_client.sync_with_cas = true

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -64,6 +64,9 @@ class Role < ActiveRecord::Base
       :can_enter_deidentified_clients,
       :can_manage_deidentified_clients,
       :can_add_cohorts_to_deidentified_clients,
+      :can_enter_identified_clients,
+      :can_manage_identified_clients,
+      :can_add_cohorts_to_identified_clients,
     ]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,4 +126,7 @@ class User < ActiveRecord::Base
     true
   end
 
+  def can_see_non_hmis_clients?
+    can_enter_deidentified_clients? || can_manage_deidentified_clients? || can_enter_identified_clients? || can_manage_identified_clients?
+  end
 end

--- a/app/views/admin/users/_form.html.haml
+++ b/app/views/admin/users/_form.html.haml
@@ -14,6 +14,7 @@
         .alert.alert-danger
           = @user.errors.messages[:email].last.humanize
       = contact_fields.input :email, as: :email, required: true
+      = f.input :agency
     .form--checkbox-groups
       %h3 CAS Roles for Access Permissions
       = f.association :roles, as: :check_boxes, label_method: :role_name, collection: Role.available_roles

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -54,7 +54,12 @@
             %tbody
               - @users.each do |user|
                 %tr
-                  %td= user.name
+                  %td
+                    .user__name
+                      = user.name
+                    - if user.agency
+                      .user__agency
+                        %em.text-muted= user.agency
                   %td
                     = user.email
                   %td= user.roles_string

--- a/app/views/deidentified_clients/_form.haml
+++ b/app/views/deidentified_clients/_form.haml
@@ -5,7 +5,7 @@
     .form-inputs
       = f.input :client_identifier, required: true
       = f.input :assessment_score
-      = f.input :agency
+      = f.input :agency, collection: @available_agencies, input_html: {class: :select2}, hint: 'You may lose access to this client record if the agency doesn\'t match your agency'
       = f.input :date_of_birth, as: :date_picker
       = f.input :days_homeless_in_the_last_three_years
       - if can_add_cohorts_to_deidentified_clients? && Warehouse::Base.enabled?
@@ -16,6 +16,10 @@
       = f.input :income_maximization_assistance_requested
       = f.input :pending_subsidized_housing_placement
       = f.input :rrh_assessment_contact_info, label: 'Case Manager Contact Information'
+      = f.input :required_number_of_bedrooms, collection: (1..5), include_blank: false
+      = f.input :required_minimum_occupancy, collection: (1..10), include_blank: false
+      = f.input :requires_wheelchair_accessibility, label: _('Requires wheelchair accessible unit')
+      = f.input :requires_elevator_access, label: _('Requires ground floor unit or elevator access')
 
     .form-actions
       = f.button :submit, "Submit", class: 'btn btn-primary'

--- a/app/views/deidentified_clients/_table.haml
+++ b/app/views/deidentified_clients/_table.haml
@@ -1,0 +1,46 @@
+.row
+  .col-sm-12
+    .table-responsive
+      %table.table.table-condensed
+        %thead
+          %th Last Name
+          %th First Name
+          %th Assessment Score
+          %th Agency
+          %th Cohorts
+          %th DOB
+          %th SSN
+          %th Days Homeless in the Last 3 Years
+          %th
+          %th
+
+        %tbody
+          - @deidentified_clients.each do |deidentified_client|
+            %tr
+              %td= deidentified_client.last_name
+              %td= deidentified_client.first_name
+              %td= deidentified_client.assessment_score
+              %td= deidentified_client.agency
+              %td= simple_format deidentified_client.cohort_names
+              %td= deidentified_client.date_of_birth
+              %td= ssn deidentified_client.ssn
+              %td= deidentified_client.days_homeless_in_the_last_three_years
+
+              - if can_manage_identified_clients?
+                - if deidentified_client.identified
+                  %td
+                    = link_to edit_identified_client_path(deidentified_client.id), class: ['btn', 'btn-sm', 'btn-secondary'] do
+                      %span.icon-pencil
+                      Edit
+                - else
+                  %td
+                    = link_to({action: :edit, id: deidentified_client}, class: ['btn', 'btn-sm', 'btn-secondary']) do
+                      %span.icon-pencil
+                      Edit
+                - if !deidentified_client.involved_in_match?
+                  %td
+                    = link_to deidentified_client_path(deidentified_client),  method: :delete, data: {confirm: "Would you really like to delete this deidentified_client?"}, class: ['btn', 'btn-sm', 'btn-danger'] do
+                      %span.icon-cross
+                      Delete
+
+%p= paginate @deidentified_clients

--- a/app/views/deidentified_clients/index.haml
+++ b/app/views/deidentified_clients/index.haml
@@ -6,48 +6,4 @@
     %span.icon-plus
     Add a Deidentifed Client
 = render 'menus/non_hmis_clients'
-
-.row
-  .col-sm-12
-    .table-responsive
-      %table.table.table-condensed
-        %thead
-          %th Last Name
-          %th First Name
-          %th Assessment Score
-          %th Agency
-          %th Cohorts
-          %th DOB
-          %th SSN
-          %th Days Homeless in the Last 3 Years
-
-        %tbody
-          - @deidentified_clients.each do |deidentified_client|
-            %tr
-              %td= deidentified_client.last_name
-              %td= deidentified_client.first_name
-              %td= deidentified_client.assessment_score
-              %td= deidentified_client.agency
-              %td= simple_format deidentified_client.cohort_names
-              %td= deidentified_client.date_of_birth
-              %td= ssn deidentified_client.ssn
-              %td= deidentified_client.days_homeless_in_the_last_three_years
-
-              - if can_manage_deidentified_clients?
-                - if deidentified_client.identified
-                  %td
-                    = link_to edit_identified_client_path(deidentified_client.id) do
-                      %span.icon-pencil
-                      Edit
-                - else
-                  %td
-                    = link_to action: :edit, id: deidentified_client do
-                      %span.icon-pencil
-                      Edit
-                - if !deidentified_client.involved_in_match?
-                  %td
-                    = link_to deidentified_client_path(deidentified_client),  method: :delete, data: {confirm: "Would you really like to delete this deidentified_client?"} do
-                      %span.icon-cross
-                      Delete
-
-%p= paginate @deidentified_clients
+= render 'table'

--- a/app/views/deidentified_clients/index.haml
+++ b/app/views/deidentified_clients/index.haml
@@ -1,19 +1,11 @@
-- title = 'Deidentifed Clients'
+- title = 'Non-HMIS Clients'
 - content_for :title, title
-
-.row
-  .col-sm-4
-    %h1= content_for :title
-  .col-sm-8.d-flex
-    .mb-2.ml-auto
-      = link_to new_deidentified_client_path, class: 'btn btn-sm btn-primary' do
-        %span.icon-plus
-        Add a Deidentifed Client
-    .mb-2.ml-2
-      = link_to new_identified_client_path, class: 'btn btn-sm btn-primary' do
-        %span.icon-plus
-        Add an #{_('Identified Client')}
-
+.d-flex
+  %h1= content_for :title
+  = link_to new_deidentified_client_path, class: 'btn btn-sm btn-primary ml-auto mb-auto' do
+    %span.icon-plus
+    Add a Deidentifed Client
+= render 'menus/non_hmis_clients'
 
 .row
   .col-sm-12

--- a/app/views/identified_clients/_form.haml
+++ b/app/views/identified_clients/_form.haml
@@ -7,7 +7,7 @@
       = f.input :last_name
       = f.input :client_identifier, required: true
       = f.input :assessment_score
-      = f.input :agency
+      = f.input :agency, collection: @available_agencies, input_html: {class: :select2}, hint: 'You may lose access to this client record if the agency doesn\'t match your agency'
       = f.input :date_of_birth, as: :date_picker
       = f.input :ssn, label: "SSN", input_html: {maxlength: 9}
       = f.input :days_homeless_in_the_last_three_years
@@ -20,6 +20,10 @@
       = f.input :income_maximization_assistance_requested
       = f.input :pending_subsidized_housing_placement
       = f.input :rrh_assessment_contact_info, label: 'Client and/orCase Manager Contact Information'
+      = f.input :required_number_of_bedrooms, collection: (1..5), include_blank: false
+      = f.input :required_minimum_occupancy, collection: (1..10), include_blank: false
+      = f.input :requires_wheelchair_accessibility, label: _('Requires wheelchair accessible unit')
+      = f.input :requires_elevator_access, label: _('Requires ground floor unit or elevator access')
 
     .form-actions
       = f.button :submit, "Submit", class: 'btn btn-primary'

--- a/app/views/identified_clients/index.haml
+++ b/app/views/identified_clients/index.haml
@@ -6,48 +6,5 @@
     %span.icon-plus
     Add a Identifed Client
 = render 'menus/non_hmis_clients'
+= render 'table'
 
-.row
-  .col-sm-12
-    .table-responsive
-      %table.table.table-condensed
-        %thead
-          %th Last Name
-          %th First Name
-          %th Assessment Score
-          %th Agency
-          %th Cohorts
-          %th DOB
-          %th SSN
-          %th Days Homeless in the Last 3 Years
-
-        %tbody
-          - @deidentified_clients.each do |deidentified_client|
-            %tr
-              %td= deidentified_client.last_name
-              %td= deidentified_client.first_name
-              %td= deidentified_client.assessment_score
-              %td= deidentified_client.agency
-              %td= simple_format deidentified_client.cohort_names
-              %td= deidentified_client.date_of_birth
-              %td= ssn deidentified_client.ssn
-              %td= deidentified_client.days_homeless_in_the_last_three_years
-
-              - if can_manage_deidentified_clients?
-                - if deidentified_client.identified
-                  %td
-                    = link_to edit_identified_client_path(deidentified_client.id) do
-                      %span.icon-pencil
-                      Edit
-                - else
-                  %td
-                    = link_to action: :edit, id: deidentified_client do
-                      %span.icon-pencil
-                      Edit
-                - if !deidentified_client.involved_in_match?
-                  %td
-                    = link_to deidentified_client_path(deidentified_client),  method: :delete, data: {confirm: "Would you really like to delete this deidentified_client?"} do
-                      %span.icon-cross
-                      Delete
-
-%p= paginate @deidentified_clients

--- a/app/views/identified_clients/index.haml
+++ b/app/views/identified_clients/index.haml
@@ -1,0 +1,53 @@
+- title = 'Non-HMIS Clients'
+- content_for :title, title
+.d-flex
+  %h1= content_for :title
+  = link_to new_identified_client_path, class: 'btn btn-sm btn-primary ml-auto mb-auto' do
+    %span.icon-plus
+    Add a Identifed Client
+= render 'menus/non_hmis_clients'
+
+.row
+  .col-sm-12
+    .table-responsive
+      %table.table.table-condensed
+        %thead
+          %th Last Name
+          %th First Name
+          %th Assessment Score
+          %th Agency
+          %th Cohorts
+          %th DOB
+          %th SSN
+          %th Days Homeless in the Last 3 Years
+
+        %tbody
+          - @deidentified_clients.each do |deidentified_client|
+            %tr
+              %td= deidentified_client.last_name
+              %td= deidentified_client.first_name
+              %td= deidentified_client.assessment_score
+              %td= deidentified_client.agency
+              %td= simple_format deidentified_client.cohort_names
+              %td= deidentified_client.date_of_birth
+              %td= ssn deidentified_client.ssn
+              %td= deidentified_client.days_homeless_in_the_last_three_years
+
+              - if can_manage_deidentified_clients?
+                - if deidentified_client.identified
+                  %td
+                    = link_to edit_identified_client_path(deidentified_client.id) do
+                      %span.icon-pencil
+                      Edit
+                - else
+                  %td
+                    = link_to action: :edit, id: deidentified_client do
+                      %span.icon-pencil
+                      Edit
+                - if !deidentified_client.involved_in_match?
+                  %td
+                    = link_to deidentified_client_path(deidentified_client),  method: :delete, data: {confirm: "Would you really like to delete this deidentified_client?"} do
+                      %span.icon-cross
+                      Delete
+
+%p= paginate @deidentified_clients

--- a/app/views/layouts/_site_menu.html.haml
+++ b/app/views/layouts/_site_menu.html.haml
@@ -15,10 +15,14 @@
         %li.o-menu__item
           = link_to clients_path, class: 'o-menu__link' do
             All Clients
-      - if can_enter_deidentified_clients? || can_manage_deidentified_clients?
+      - if current_user.can_see_non_hmis_clients?
         %li.o-menu__item
-          = link_to deidentified_clients_path, class: 'o-menu__link' do
-            #{_('Non-HMIS Clients')}
+          - if can_enter_deidentified_clients? || can_manage_deidentified_clients?
+            = link_to deidentified_clients_path, class: 'o-menu__link' do
+              #{_('Non-HMIS Clients')}
+          - else
+            = link_to identified_clients_path, class: 'o-menu__link' do
+              #{_('Non-HMIS Clients')}
       - if can_view_contacts?
         %li.o-menu__item
           = link_to contacts_path, class: 'o-menu__link' do

--- a/app/views/menus/_non_hmis_clients.haml
+++ b/app/views/menus/_non_hmis_clients.haml
@@ -1,0 +1,7 @@
+%ul.nav.nav-tabs
+  -if can_enter_deidentified_clients?
+    %li.nav-item{role: "presentation", class: ('active' if current_page?(deidentified_clients_path))}
+      = link_to 'Deidentified Clients', deidentified_clients_path, class: 'nav-link'
+  -if can_enter_identified_clients?
+    %li.nav-item{role: "presentation", class: ('active' if current_page?(identified_clients_path))}
+      = link_to 'Identified Clients', identified_clients_path, class: 'nav-link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,8 +124,8 @@ Rails.application.routes.draw do
     get :cache_status
   end
 
-  resources :deidentified_clients, only: [:index, :new, :create, :edit, :update, :destroy] 
-  resources :identified_clients, only: [:new, :create, :edit, :update] 
+  resources :deidentified_clients
+  resources :identified_clients
   
   resources :messages, only: [:show, :index] do
     collection do

--- a/db/migrate/20181018174118_add_identified_client_permissions.rb
+++ b/db/migrate/20181018174118_add_identified_client_permissions.rb
@@ -1,0 +1,11 @@
+class AddIdentifiedClientPermissions < ActiveRecord::Migration
+  def up
+    Role.ensure_permissions_exist
+  end
+  
+  def down
+    remove_column :roles, :can_enter_identified_clients, :boolean
+    remove_column :roles, :can_manage_identified_clients, :boolean
+    remove_column :roles, :can_add_cohorts_to_identified_clients, :boolean
+  end
+end

--- a/db/migrate/20181019124944_add_agency_to_user.rb
+++ b/db/migrate/20181019124944_add_agency_to_user.rb
@@ -1,0 +1,5 @@
+class AddAgencyToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :agency, :string
+  end
+end

--- a/db/migrate/20181019154323_additional_deidentified_fields.rb
+++ b/db/migrate/20181019154323_additional_deidentified_fields.rb
@@ -1,0 +1,8 @@
+class AdditionalDeidentifiedFields < ActiveRecord::Migration
+  def change
+    add_column :deidentified_clients, :requires_wheelchair_accessibility, :boolean, default: false, null: false
+    add_column :deidentified_clients, :required_number_of_bedrooms, :integer, default: 1
+    add_column :deidentified_clients, :required_minimum_occupancy, :integer, default: 1
+    add_column :deidentified_clients, :requires_elevator_access, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018174118) do
+ActiveRecord::Schema.define(version: 20181019154323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -287,6 +287,10 @@ ActiveRecord::Schema.define(version: 20181018174118) do
     t.boolean  "income_maximization_assistance_requested", default: false, null: false
     t.boolean  "pending_subsidized_housing_placement",     default: false, null: false
     t.boolean  "full_release_on_file",                     default: false, null: false
+    t.boolean  "requires_wheelchair_accessibility",        default: false, null: false
+    t.integer  "required_number_of_bedrooms",              default: 1
+    t.integer  "required_minimum_occupancy",               default: 1
+    t.boolean  "requires_elevator_access",                 default: false, null: false
   end
 
   add_index "deidentified_clients", ["deleted_at"], name: "index_deidentified_clients_on_deleted_at", using: :btree
@@ -1049,6 +1053,7 @@ ActiveRecord::Schema.define(version: 20181018174118) do
     t.string   "last_name"
     t.string   "email_schedule",               default: "immediate", null: false
     t.boolean  "active",                       default: true,        null: false
+    t.string   "agency"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181008141707) do
+ActiveRecord::Schema.define(version: 20181018174118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -171,7 +171,7 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.boolean  "disabling_condition",                                    default: false
     t.datetime "release_of_information"
     t.date     "prevent_matching_until"
-    t.boolean  "dmh_eligible",                                           default: false, null: false
+    t.boolean  "dmh_eligible",                                           default: false
     t.boolean  "va_eligible",                                            default: false, null: false
     t.boolean  "hues_eligible",                                          default: false, null: false
     t.datetime "disability_verified_on"
@@ -196,8 +196,8 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.integer  "vispdat_priority_score",                                 default: 0
     t.integer  "vispdat_length_homeless_in_days",                        default: 0,     null: false
     t.boolean  "cspech_eligible",                                        default: false
-    t.date     "calculated_last_homeless_night"
     t.string   "alternate_names"
+    t.date     "calculated_last_homeless_night"
     t.boolean  "congregate_housing",                                     default: false
     t.boolean  "sober_housing",                                          default: false
     t.jsonb    "enrolled_project_ids"
@@ -680,7 +680,7 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.string   "workphone"
     t.string   "pager"
     t.string   "email"
-    t.boolean  "dmh_eligible",                                default: false, null: false
+    t.boolean  "dmh_eligible",                                default: false
     t.boolean  "va_eligible",                                 default: false, null: false
     t.boolean  "hues_eligible",                               default: false, null: false
     t.datetime "disability_verified_on"
@@ -785,7 +785,6 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.boolean  "can_edit_all_clients",                    default: false
     t.boolean  "can_participate_in_matches",              default: false
     t.boolean  "can_view_all_matches",                    default: false
-    t.boolean  "can_view_own_closed_matches",             default: false
     t.boolean  "can_see_alternate_matches",               default: false
     t.boolean  "can_edit_match_contacts",                 default: false
     t.boolean  "can_approve_matches",                     default: false
@@ -796,11 +795,6 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.boolean  "can_edit_users",                          default: false
     t.boolean  "can_view_full_ssn",                       default: false
     t.boolean  "can_view_full_dob",                       default: false
-    t.boolean  "can_view_dmh_eligibility",                default: false
-    t.boolean  "can_view_va_eligibility",                 default: false
-    t.boolean  "can_view_hues_eligibility",               default: false
-    t.boolean  "can_view_hiv_positive_eligibility",       default: false
-    t.boolean  "can_view_client_confidentiality",         default: false
     t.boolean  "can_view_buildings",                      default: false
     t.boolean  "can_edit_buildings",                      default: false
     t.boolean  "can_view_funding_sources",                default: false
@@ -825,7 +819,13 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.boolean  "can_edit_available_services",             default: false
     t.boolean  "can_assign_services",                     default: false
     t.boolean  "can_assign_requirements",                 default: false
+    t.boolean  "can_view_dmh_eligibility",                default: false
+    t.boolean  "can_view_va_eligibility",                 default: false, null: false
+    t.boolean  "can_view_hues_eligibility",               default: false, null: false
     t.boolean  "can_become_other_users",                  default: false
+    t.boolean  "can_view_client_confidentiality",         default: false, null: false
+    t.boolean  "can_view_hiv_positive_eligibility",       default: false
+    t.boolean  "can_view_own_closed_matches",             default: false
     t.boolean  "can_edit_translations",                   default: false
     t.boolean  "can_view_vspdats",                        default: false
     t.boolean  "can_manage_config",                       default: false
@@ -834,6 +834,9 @@ ActiveRecord::Schema.define(version: 20181008141707) do
     t.boolean  "can_manage_deidentified_clients",         default: false
     t.boolean  "can_add_cohorts_to_deidentified_clients", default: false
     t.boolean  "can_delete_client_notes",                 default: false
+    t.boolean  "can_enter_identified_clients",            default: false
+    t.boolean  "can_manage_identified_clients",           default: false
+    t.boolean  "can_add_cohorts_to_identified_clients",   default: false
   end
 
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree


### PR DESCRIPTION
This breaks apart de-identified and identified clients, adds permissions such that a non-administrative user can only see un-assigned non-HMIS clients, or those assigned to their agency, and adds additional attributes for non-HMIS clients.