### PR TITLE
Ensure client availability on routes

### DIFF
--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -2,6 +2,7 @@ class Client < ActiveRecord::Base
 
   include SubjectForMatches
   include MatchArchive
+  include Availability
 
   has_paper_trail
   acts_as_paranoid

--- a/app/models/concerns/availability.rb
+++ b/app/models/concerns/availability.rb
@@ -1,0 +1,28 @@
+# Tools for ensuring client availability
+module Availability
+  
+  extend ActiveSupport::Concern
+  included do
+    def ensure_availability
+      self.class.transaction do
+        unavailable_as_candidate_fors.destroy_all
+        unavailable_routes.each do |route|
+          self.make_unavailable_in match_route: route
+        end
+      end
+    end
+
+    # any routes with active or successful matches
+    def unavailable_routes
+      (active_routes + successful_routes).uniq
+    end
+
+    def active_routes
+      client_opportunity_matches.active.map(&:match_route).uniq
+    end
+
+    def successful_routes
+      client_opportunity_matches.success.map(&:match_route).uniq
+    end
+  end
+end


### PR DESCRIPTION
Client availability on a given route is controlled by the existence of `UnavailableAsCandidateFor` records.  Historically these have been a bit of a problem to maintain.  They are generally added and removed by the callbacks executed when a match changes state.  These are:

`ClientOpportunityMatch#activate!`
`ClientOpportunityMatch#activate!`
`ClientOpportunityMatch#activate!`