### PR TITLE
Manually set direction and sort for paginate

### DIFF
--- a/app/views/clients/_client_list.haml
+++ b/app/views/clients/_client_list.haml
@@ -73,4 +73,4 @@
               %th.text-center
                 = checkmark client.chronic_homeless
 
-    %p= paginate clients
+    %p= paginate clients, params: {direction: @direction, sort: @column}


### PR DESCRIPTION
Kaminari was guessing badly on the pagination parameters, which was messing up the sort. So, this explicitly sets them.