### PR TITLE
Skip order_as_specified if no ids

### DIFF
--- a/app/controllers/active_matches_controller.rb
+++ b/app/controllers/active_matches_controller.rb
@@ -32,9 +32,9 @@ class ActiveMatchesController < MatchListBaseController
       map(&:first).
       uniq
 
-    @opportunities = opportunity_scope.where(id: opportunity_ids).
-      order_as_specified(distinct_on: true, id: opportunity_ids).
-      # order("array_position(ARRAY#{opportunity_ids}, opportunities.id)").
+    @opportunities = opportunity_scope.where(id: opportunity_ids)
+    @opportunities = @opportunities.order_as_specified(distinct_on: true, id: opportunity_ids) unless opportunity_ids.empty?
+    @opportunities = @opportunities.
       preload(
         :voucher,
         :match_route,


### PR DESCRIPTION
This is to address the errors:
```
PG::SyntaxError: ERROR:  syntax error at or near ")"
LINE 1: SELECT  DISTINCT ON () "opportunities".* FROM "opportunities...
```
in the logs... if you pass an empty array to `order_as_specified` it generates empty parens.