### PR TITLE
Clean up for rolled back successful matches

### DIFF
--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -508,6 +508,9 @@ class ClientOpportunityMatch < ApplicationRecord
       update(closed: false, active: true, closed_reason: nil)
       current_decision.update(status: :pending)
       MatchEvents::Reopened.create(match_id: id, contact_id: contact.id)
+      # If this match was picked up in nightly processing, the client now appears as housed in the warehouse,
+      # so clean that up...
+      Warehouse::CasHoused.where(match_id: id).destroy_all
     end
   end
 

--- a/app/models/warehouse/flag_housed.rb
+++ b/app/models/warehouse/flag_housed.rb
@@ -6,10 +6,14 @@
 
 module Warehouse
   class FlagHoused
-    def run!
+    def run!(clear=false)
       processed = Warehouse::CasHoused.all
-      housed_in_cas = ClientOpportunityMatch.should_alert_warehouse
-      to_add = housed_in_cas.where.not(id: processed.pluck(:match_id))
+      to_add = ClientOpportunityMatch.should_alert_warehouse
+      if clear
+        Warehouse::CasHoused.destroy_all
+      else
+        to_add = to_add.where.not(id: processed.pluck(:match_id))
+      end
       to_add.each do |match|
         warehouse_client_id = match.client.project_client.id_in_data_source
         cas_client_id = match.client.id

--- a/lib/tasks/warehouse.rake
+++ b/lib/tasks/warehouse.rake
@@ -6,8 +6,9 @@ namespace :warehouse do
   end
 
   desc "Flag CAS housed clients in the warehouse"
-  task flag_housed: [:environment, "log:info_to_stdout"] do
-    Warehouse::FlagHoused.new.run! if Warehouse::Base.enabled?
+  task :flag_housed, [:clear] => [:environment, "log:info_to_stdout"] do |_, args|
+    clear = args[:clear] == 'clear'
+    Warehouse::FlagHoused.new.run!(clear) if Warehouse::Base.enabled?
   end
 
 end


### PR DESCRIPTION
`rails 'warehouse:flag_housed[clear]'` will force a rebuild of CasHoused.