### PR TITLE
Remove expires? from step

### DIFF
--- a/app/models/match_decisions/four/match_recommendation_hsa.rb
+++ b/app/models/match_decisions/four/match_recommendation_hsa.rb
@@ -44,10 +44,6 @@ module MatchDecisions::Four
       _('HSA')
     end
 
-    def expires?
-      true
-    end
-
     def contact_actor_type
       :housing_subsidy_admin_contacts
     end


### PR DESCRIPTION
I think we will also need to run
`ClientOpportunityMatch.open.select { |m| m.current_decision.type == 'MatchDecisions::Four::MatchRecommendationHsa' }.update(shelter_expiration: nil)`
To remove the expiration dates from any current step 3s.