### PR TITLE
Adjust which steps decline_overridden initializes

### DIFF
--- a/app/models/match_decisions/four/confirm_hsa_initial_decline_dnd_staff.rb
+++ b/app/models/match_decisions/four/confirm_hsa_initial_decline_dnd_staff.rb
@@ -81,7 +81,7 @@ module MatchDecisions::Four
       end
 
       def decline_overridden
-        match.four_record_client_housed_date_housing_subsidy_administrator_decision.initialize_decision!
+        match.four_schedule_criminal_hearing_housing_subsidy_admin_decision.initialize_decision!
       end
 
       def decline_overridden_returned

--- a/app/models/match_decisions/four/confirm_shelter_agency_decline_dnd_staff.rb
+++ b/app/models/match_decisions/four/confirm_shelter_agency_decline_dnd_staff.rb
@@ -76,7 +76,7 @@ module MatchDecisions::Four
       end
 
       def decline_overridden
-        match.four_schedule_criminal_hearing_housing_subsidy_admin_decision.initialize_decision!
+        match.four_match_recommendation_hsa_decision.initialize_decision!
         # TODO notify shelter agency of decline override
       end
 


### PR DESCRIPTION
Also created a story to adjust the 'back' button as it does not correctly handle cases where there was an overridden decline.