### PR TITLE
Add ability to rebuild pre-cache image

### DIFF
--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -57,6 +57,17 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
+    - name: Delete pre-cache image?
+      env:
+        ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+      run: |
+        if git log -1 | fgrep '[gh:rebuild]' ;
+        then
+          echo 'Deleting pre-cache image...'
+          export RUBY_VERSION=`cat .ruby-version`
+          aws ecr batch-delete-image --repository-name ${ECR_REPOSITORY} --image-ids imageTag="${RUBY_VERSION}--pre-cache"
+        fi
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:


### PR DESCRIPTION
Clones https://github.com/greenriver/hmis-warehouse/pull/1872

This adds the ability to rebuild the pre-cache image by including `[gh:rebuild]` in the commit message, and thereby brings boston-cas into line with the most up-to-date pre-cache image handling methodology.