### PR TITLE
Prefer days_homeless from assessment if available

### DIFF
--- a/app/models/deidentified_tc_hat.rb
+++ b/app/models/deidentified_tc_hat.rb
@@ -23,7 +23,7 @@ class DeidentifiedTcHat < DeidentifiedClientAssessment
       'Agency',
     ]
     columns << 'Assessment Date'
-    columns << 'Days Homeless in the Last 3 Years'
+    columns << 'Days Homeless'
     columns << 'Status'
     columns << 'CAS Client' if user.can_view_some_clients?
     columns << '' if user.can_manage_deidentified_clients?
@@ -58,7 +58,7 @@ class DeidentifiedTcHat < DeidentifiedClientAssessment
       end
     end
     row << assessment_date
-    row << current_assessment&.days_homeless_in_the_last_three_years
+    row << current_assessment&.days_homeless
     row << if client.available then 'Available' else 'Ineligible' end
     row << client_link if user.can_view_some_clients?
     row << delete_link if user.can_manage_deidentified_clients?

--- a/app/models/non_hmis_client.rb
+++ b/app/models/non_hmis_client.rb
@@ -206,7 +206,7 @@ class NonHmisClient < ApplicationRecord
     project_client.assessment_score = current_assessment&.assessment_score || 0
     project_client.days_homeless_in_last_three_years = current_assessment&.total_days_homeless_in_the_last_three_years || 0
     project_client.days_literally_homeless_in_last_three_years = current_assessment&.total_days_homeless_in_the_last_three_years || 0
-    project_client.days_homeless = current_assessment&.total_days_homeless_in_the_last_three_years || 0
+    project_client.days_homeless = current_assessment&.days_homeless || current_assessment&.total_days_homeless_in_the_last_three_years || 0
     project_client.hmis_days_homeless_last_three_years = current_assessment&.days_homeless_in_the_last_three_years
     project_client.date_days_homeless_verified = current_assessment&.date_days_homeless_verified
     project_client.who_verified_days_homeless = current_assessment&.who_verified_days_homeless


### PR DESCRIPTION
When calculating cumulative days homeless for a non-HMIS client, this now uses `days_homeless` in preference to `days_homeless_in_last_three_years`.  In addition, if you choose the TC HAT assessment, it will display days homeless on the list page instead of days homeless in the past 3 years.