### PR TITLE
Update BUNDLER_VERSION to match lockfile

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ x-app: &app
       PG_MAJOR: '12'
       NODE_MAJOR: '12'
       YARN_VERSION: '1.17.3'
-      BUNDLER_VERSION: '1.17.3'
+      BUNDLER_VERSION: '2.3.8'
       ADDITIONAL_PACKAGES: vim nodejs python2 unzip xvfb google-chrome-stable less freetds-dev freetds-bin phantomjs xfonts-75dpi alien libpng-dev libicu-dev libcurl4-openssl-dev curl libmagic-dev libmagickcore-dev libmagickwand-dev
   environment: &env
     NODE_ENV: ${NODE_ENV:-development}


### PR DESCRIPTION
https://github.com/greenriver/boston-cas/commit/d257ea286b11e71cbeb3d57ee184267b20d759a1 updated the gem lock file without updating the bundler version for the docker build. This results in an error when building the container (`You must use Bundler 2 or greater with this lockfile`).