### PR TITLE
Fix nokogiri install

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apk add --no-cache \
   shared-mime-info \
   vim less \
   tar \
+  xz \
   python3 py3-pip \
   && git config --global --add safe.directory /app \
   && ln -s libproj.so.21.1.2 /usr/lib/libproj.so.20


### PR DESCRIPTION
https://github.com/greenriver/boston-cas/pull/605 didn't fully do the trick, I'm also hitting this error when installing nokogiri https://nokogiri.org/tutorials/installing_nokogiri.html#tar-child-xz-cannot-exec-no-such-file-or-directory
Installing `xz` fixes it