### PR TITLE
Pin alpine to 3.15

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Based on https://github.com/ledermann/docker-rails/blob/develop/Dockerfile
 ARG RUBY_VERSION
 # NOTE FROM clears all ARGs
-FROM ruby:$RUBY_VERSION-alpine
+FROM ruby:$RUBY_VERSION-alpine3.15
 
 ARG PG_MAJOR
 ARG NODE_MAJOR


### PR DESCRIPTION
Do we want to pin alpine at 3.15 for cas, like we did for the warehouse?
Seems like 3.16 is working fine, but I just noticed the inconsistency.