### PR TITLE
Work around race condition where deleted clients get matched - 182760774

### DIFF
--- a/app/controllers/opportunity_matches_controller.rb
+++ b/app/controllers/opportunity_matches_controller.rb
@@ -15,7 +15,7 @@ class OpportunityMatchesController < ApplicationController
 
   def index
     clients_for_route = Client.available_for_matching(@opportunity.match_route)
-    @actives = @opportunity.active_matches.map { |match| match.client }
+    @actives = @opportunity.active_matches.map { |match| match.client }.compact
     @availables = @opportunity.matching_clients(clients_for_route)
     @matches = (@actives + @availables).uniq
     @sub_program = @opportunity.sub_program

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -643,7 +643,7 @@ class ClientOpportunityMatch < ApplicationRecord
   def poached!
     self.class.transaction do
       update! active: false, closed: true, closed_reason: 'canceled'
-      client.make_available_in(match_route: match_route)
+      client&.make_available_in(match_route: match_route)
       opportunity.update! available_candidate: false
       opportunity.try(:voucher).try(:sub_program).try(:update_summary!)
       # Prevent access to this match by notification after 1 week

--- a/app/views/opportunity_matches/_activate_button.haml
+++ b/app/views/opportunity_matches/_activate_button.haml
@@ -2,7 +2,7 @@
   - match_warning = "Activating this match will cancel all other active matches for #{client.name} on the #{@opportunity.match_route.title}."
 - else
   - match_warning = ''
-- if @opportunity.active_matches.exists?
+- if @opportunity.active_matches.exists? && @opportunity.active_matches.first.client.present?
   - text = 'Activate Match Canceling Current'
   - if match_warning.present?
     - match_warning += " In addition, it will cancel the current match involving #{@opportunity.active_matches.first.client.name}."


### PR DESCRIPTION
1. Every 5 minutes, delete any `ClientOpportunityMatch` that points to a deleted client
2. If someone pulls up the Opportunity page that has a match afflicted by this race condition (in the 5min before it is removed), hide the match from the page and make sure the app doesn't blow up