### PR TITLE
Decline reason updates

### DIFF
--- a/app/models/match_decisions/record_client_housed_date_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/record_client_housed_date_housing_subsidy_administrator.rb
@@ -78,6 +78,20 @@ module MatchDecisions
       super + [:client_move_in_date]
     end
 
+    def step_decline_reasons(_contact)
+      [
+        'Client has another housing option',
+        'Does not agree to services',
+        'Unwilling to live in that neighborhood',
+        'Unwilling to live in SRO',
+        'Does not want housing at this time',
+        'Unsafe environment for this person',
+        'Client refused unit (non-SRO)',
+        'Client refused voucher',
+        'Health and Safety',
+      ]
+    end
+
     def initialize_decision! send_notifications: true
       super(send_notifications: send_notifications)
       update(status: 'pending')

--- a/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
@@ -86,6 +86,7 @@ module MatchDecisions
         'Unsafe environment for this person',
         'Client refused unit (non-SRO)',
         'Client refused voucher',
+        'Health and Safety',
       ]
     end
 


### PR DESCRIPTION
This exposes Health and Safety as decline reasons on the default match route steps 3 and 5.