### PR TITLE
Mailhog removal

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -73,7 +73,6 @@ services:
     depends_on:
       - db
       - redis
-      - mailhog
 
   dj:
     <<: *backend
@@ -89,9 +88,15 @@ services:
     tty: true
     command: bundle exec rails server -b 0.0.0.0
     labels:
-      - "traefik.http.routers.op.rule=Host(`open-path-cas.127.0.0.1.nip.io`)"
-      - "traefik.http.routers.op.tls=true"
-      - "traefik.http.services.op.loadbalancer.server.port=3000"
+      - traefik.enable=true
+      - traefik.http.routers.op.entrypoints=web
+      - traefik.http.routers.op.rule=Host(`boston-cas.dev.test`)
+      - traefik.http.services.cas_https.loadbalancer.server.port=3000
+      - traefik.http.routers.cas_https.rule=Host(`boston-cas.dev.test`)
+      - traefik.http.routers.cas_https.tls=true
+      - traefik.http.routers.cas_https.entrypoints=web-secure
+      - traefik.http.middlewares.cas_https.redirectscheme.scheme=https
+      - traefik.http.routers.op.middlewares=cas_https
     expose:
       - 3000
     environment:
@@ -101,7 +106,6 @@ services:
     depends_on:
       - db
       - redis
-      - mailhog
 
   db:
     image: postgres:12-alpine
@@ -119,16 +123,6 @@ services:
       - redis:/data
     ports:
       - 6379
-
-  mailhog:
-    image: mailhog/mailhog:latest
-    restart: always
-    environment:
-      VIRTUAL_HOST: mail.${FQDN:-boston-cas.dev.test}
-      VIRTUAL_PORT: 8025
-    expose:
-      - 8025
-      - 1025
 
 secrets:
   host_ssh_key:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -89,14 +89,14 @@ services:
     command: bundle exec rails server -b 0.0.0.0
     labels:
       - traefik.enable=true
-      - traefik.http.routers.op.entrypoints=web
-      - traefik.http.routers.op.rule=Host(`boston-cas.dev.test`)
+      - traefik.http.routers.cas.entrypoints=web
+      - traefik.http.routers.cas.rule=Host(`boston-cas.dev.test`)
       - traefik.http.services.cas_https.loadbalancer.server.port=3000
       - traefik.http.routers.cas_https.rule=Host(`boston-cas.dev.test`)
       - traefik.http.routers.cas_https.tls=true
       - traefik.http.routers.cas_https.entrypoints=web-secure
       - traefik.http.middlewares.cas_https.redirectscheme.scheme=https
-      - traefik.http.routers.op.middlewares=cas_https
+      - traefik.http.routers.cas.middlewares=cas_https
     expose:
       - 3000
     environment:
@@ -137,4 +137,5 @@ volumes:
 
 networks:
   default:
-    name: nginx-proxy
+    name: traefik
+    external: true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -88,11 +88,11 @@ services:
     tty: true
     command: bundle exec rails server -b 0.0.0.0
     labels:
-      - traefik.enable=true
+      - traefik.enable=${TRAEFIK_ENABLED:-false}
       - traefik.http.routers.cas.entrypoints=web
-      - traefik.http.routers.cas.rule=Host(`boston-cas.dev.test`)
+      - traefik.http.routers.cas.rule=Host(`${FQDN:-boston-cas.dev.test}`)
       - traefik.http.services.cas_https.loadbalancer.server.port=3000
-      - traefik.http.routers.cas_https.rule=Host(`boston-cas.dev.test`)
+      - traefik.http.routers.cas_https.rule=Host(`${FQDN:-boston-cas.dev.test}`)
       - traefik.http.routers.cas_https.tls=true
       - traefik.http.routers.cas_https.entrypoints=web-secure
       - traefik.http.middlewares.cas_https.redirectscheme.scheme=https

--- a/docs/developer-networking.md
+++ b/docs/developer-networking.md
@@ -15,3 +15,25 @@ Mail delivery is done through [MailHog, please see documentation in the Warehous
 
 ## DNS
 DNS is handled by [Traefik, please see documentation in the Warehouse](https://github.com/greenriver/hmis-warehouse/blob/6a4100102293a21d7d0d8d31e0a6ec18728d39ce/docs/traefik/developer-network.md)
+
+### DIRENV
+
+If not already set up, install DIRENV. You will need to allow the changes after updating the file.
+
+```
+brew install direnv
+direnv allow
+```
+
+Append your `.envrc` with the following 
+
+```
+export FQDN=boston-cas.dev.test
+export TRAEFIK_ENABLED=true
+```
+
+Allow the file changes through direnv
+```
+direnv allow
+```
+For direnv to work properly it needs to be hooked into the shell. Each shell has its own extension mechanism. Complete the [setup instructions](https://direnv.net/docs/hook.html) for  your shell.

--- a/docs/developer-networking.md
+++ b/docs/developer-networking.md
@@ -1,80 +1,17 @@
-# Developer Setup for Docker Networking and Local Email
+# Developer Networking Setup
 
 This document is specific to the Mac environment, since that's generally what Green River uses, but most of the steps are platform agnostic, and the concepts can be extended to any environment.
 
-The following three items will make development much more seamless.
+Networking and mail delivery mostly exists as dependencies external to CAS, and shared with the warehouse.
 
-1. Setup DNS resolution for a set of domains to be used for development to point to your local development machine.
-
-2. Create and trust a self-signed certificate to allow for development access over SSL.
-
-3. Setup of an nginx-proxy server to route requests to the appropriate docker container.
-
-## DNS setup
-These instructions are loosely based on https://gist.github.com/jed/6147872
-
-If you don't have [Homebrew](http://brew.sh/) installed yet, follow the [instructions on that site](http://brew.sh/).
-
-* Install dnsmasq to route DNS requests for `*.dev.test` to your local machine
-```
-brew install dnsmasq
-mkdir -pv $(brew --prefix)/etc
-sudo mkdir -pv /etc/resolver
-echo "address=/.test/127.0.0.1" | sudo tee -a $(brew --prefix)/etc/dnsmasq.conf
-echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/dev.test
-sudo brew services start dnsmasq
-```
-
-It can be very helpful to add the following lines to your `/etc/hosts` file to allow non-docker development to work in conjunction with dockerized workflows.
+To easily access the application, you'll want to add the following line to `/etc/hosts` on your host machine.
 
 ```
-# Docker Compose mirror so we can leave our .env files alone
-127.0.0.1 host.docker.internal
+127.0.0.1 boston-cas.dev.test
 ```
 
-## Certificate
-We'll generate a self-signed certificates for nginx-proxy to use to serve our site over ssl.  Before you begin this, make sure you are in the root directory of the application.
-```
-cd docker/nginx-proxy/certs
-cat > openssl.cnf <<-EOF
-  [req]
-  distinguished_name = req_distinguished_name
-  x509_extensions = v3_req
-  prompt = no
-  [req_distinguished_name]
-  CN = *.dev.test
-  [v3_req]
-  keyUsage = keyEncipherment, dataEncipherment
-  extendedKeyUsage = serverAuth
-  subjectAltName = @alt_names
-  [alt_names]
-  DNS.1 = *.dev.test
-  DNS.2 = dev.test
-EOF
+## Mail
+Mail delivery is done through [MailHog, please see documentation in the Warehouse](https://github.com/greenriver/hmis-warehouse/blob/stable/docs/mailhog/developer-mail.md)
 
-openssl req \
-  -new \
-  -newkey rsa:2048 \
-  -sha256 \
-  -days 3650 \
-  -nodes \
-  -x509 \
-  -keyout dev.test.key \
-  -out dev.test.crt \
-  -config openssl.cnf
-
-rm openssl.cnf
-open dev.test.crt
-```
-
-When prompted to add the certificate to your Keychain, choose the System keychain.  After verifying that you are an administrator, search for `dev.test` in Keychain Access and double click the certificate.  Open the Trust section and in the top drop-down select Always Trust.
-
-# Nginx Proxy
-
-Before you begin this, make sure you are in the root directory of the application.
-
-```
-cd docker/nginx-proxy
-docker network create nginx-proxy
-docker-compose up -d
-```
+## DNS
+DNS is handled by [Traefik, please see documentation in the Warehouse](https://github.com/greenriver/hmis-warehouse/blob/6a4100102293a21d7d0d8d31e0a6ec18728d39ce/docs/traefik/developer-network.md)


### PR DESCRIPTION
This removes mailhog making it an external dependency.  It updates some documentation to point to warehouse versions (that are not yet published.)

Actual warehouse documentation is here:
Mailhog
https://github.com/greenriver/hmis-warehouse/blob/6a4100102293a21d7d0d8d31e0a6ec18728d39ce/docs/mailhog/developer-mail.md

Traefik
https://github.com/greenriver/hmis-warehouse/blob/6a4100102293a21d7d0d8d31e0a6ec18728d39ce/docs/traefik/developer-network.md