### PR TITLE
Update missing rule text for housing barrier rule to correctly reference itself

### DIFF
--- a/app/models/rules/housing_barrier.rb
+++ b/app/models/rules/housing_barrier.rb
@@ -3,7 +3,7 @@ class Rules::HousingBarrier < Rule
     if Client.column_names.include?(:housing_barrier.to_s)
       scope.where(housing_barrier: requirement.positive)
     else
-      raise RuleDatabaseStructureMissing.new("clients.enrolled_in_th missing. Cannot check clients against #{self.class}.")
+      raise RuleDatabaseStructureMissing.new("clients.housing_barrier missing. Cannot check clients against #{self.class}.")
     end
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add New Rul for Service Need Indicators

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
