### PR TITLE
Account mailer adjustments

### DIFF
--- a/app/mailers/account_mailer.rb
+++ b/app/mailers/account_mailer.rb
@@ -7,12 +7,10 @@
 class AccountMailer < Devise::Mailer
   default template_path: 'devise/mailer'
 
-  if ENV['SES_MONITOR_OUTGOING_EMAIL'] == 'true'
-    ActionMailer::Base.register_interceptor CloudwatchEmailInterceptor
-  end
+  ActionMailer::Base.register_interceptor CloudwatchEmailInterceptor if ENV['SES_MONITOR_OUTGOING_EMAIL'] == 'true'
 
   def invitation_instructions(record, action, opts = {})
-    opts[:subject] = _('CAS') + ": Account Activation Instructions"
+    opts[:subject] = _('Boston Coordinated Access') + ': Account Activation Instructions'
     super
   end
 end


### PR DESCRIPTION
This adjusts the subject of the account mailer to use the site header translation instead of the simpler `CAS`.  