### PR TITLE
Update Pathwasy v4 to use existing rrh_desire column

### DIFF
--- a/app/models/concerns/pathways_version_four_calculations.rb
+++ b/app/models/concerns/pathways_version_four_calculations.rb
@@ -1048,7 +1048,7 @@ module PathwaysVersionFourCalculations
             },
           },
         },
-        interested_in_rapid_rehousing: {
+        rrh_desired: {
           label: 'Are you interested Rapid Re-Housing?',
           number: '7',
           as: :pretty_boolean_group,

--- a/app/models/non_hmis_assessment.rb
+++ b/app/models/non_hmis_assessment.rb
@@ -308,7 +308,6 @@ class NonHmisAssessment < ActiveRecord::Base
       :fifty_five_plus,
       :have_tenant_voucher,
       :interested_in_disabled_housing,
-      :interested_in_rapid_rehousing,
       :mental_health_problem,
       :older_than_65,
       :one_br_ok,

--- a/db/migrate/20240130195037_pathways_rrh_column_cleanup.rb
+++ b/db/migrate/20240130195037_pathways_rrh_column_cleanup.rb
@@ -1,0 +1,5 @@
+class PathwaysRrhColumnCleanup < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :non_hmis_assessments, :interested_in_rapid_rehousing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_23_130412) do
+ActiveRecord::Schema.define(version: 2024_01_30_195037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -985,7 +985,6 @@ ActiveRecord::Schema.define(version: 2024_01_23_130412) do
     t.text "agency_name"
     t.text "agency_day_contact_info"
     t.text "agency_night_contact_info"
-    t.boolean "interested_in_rapid_rehousing"
     t.boolean "pregnant_or_parent"
     t.text "partner_warehouse_id"
     t.text "partner_name"


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Update the Pathwasy v4 assessment to utilize the existing rrh_desired column and as with that, have the field work with the existing "Interested in RRH" rule.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [X] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [X] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
