### PR TITLE
Fix for transfer assessments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,6 @@ jobs:
         run: |
           bundle install --jobs 4 --retry 3
 
-      - uses: actions/checkout@v3
-      - name: 'Install gems'
-        run: |
-          bundle install --jobs 4 --retry 3
       - name: Run bundle-audit
         run: |
           bundle exec bundle-audit check --update --ignore CVE-2019-16676 CVE-2017-1002201

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,18 @@ jobs:
         ports:
           - 6379:6379
 
+    env:
+      DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
+      DATABASE_DB_TEST: boston_cas_test
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up dependencies
-        env:
-          DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
-          DATABASE_DB_TEST: boston_cas_test
+
         run: |
           apk add --no-cache \
+            nodejs yarn npm \
+            tzdata \
             git \
             bash \
             freetds-dev \
@@ -65,6 +70,10 @@ jobs:
           yarn install --frozen-lockfile
           gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
           gem install bundler -v '< 2'
+
+      - name: 'Install gems'
+        run: |
+          bundle install --jobs 4 --retry 3
 
       - uses: actions/checkout@v3
       - name: 'Install gems'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     # Docker Hub image that the job executes in
-    container: ruby:2.7.2-slim-buster
+    container: ruby:3.1.4-alpine3.18
 
     # Service containers to run with job
     services:
@@ -45,32 +45,27 @@ jobs:
           DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
           DATABASE_DB_TEST: boston_cas_test
         run: |
-          apt-get update
-          apt-get install -y \
-            build-essential \
-            curl \
-            freetds-bin \
-            freetds-dev \
+          apk add --no-cache \
             git \
-            icu-devtools \
+            bash \
+            freetds-dev \
+            icu icu-dev \
+            curl libcurl curl-dev \
             imagemagick \
-            libc6-dev \
-            libcurl4-openssl-dev \
-            libgeos-dev \
-            libicu-dev \
-            libmagic-dev \
-            libpq-dev \
-            libproj-dev \
-            postgis \
-            postgresql-client \
-            python \
-            unzip
+            libmagic file-dev file \
+            build-base libxml2-dev libxslt-dev postgresql-dev \
+            libgcc libstdc++ libx11 glib libxrender libxext libintl ttf-dejavu ttf-droid ttf-freefont ttf-liberation ttf-freefont \
+            freetype freetype-dev harfbuzz ca-certificates ttf-freefont \
+            postgresql tmux postgis geos geos-dev xz \
+            shared-mime-info
 
           echo "postgres:5432:*:postgres:postgres" > ~/.pgpass
           chmod 600 ~/.pgpass
 
+          yarn install --frozen-lockfile
           gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
           gem install bundler -v '< 2'
+
       - uses: actions/checkout@v3
       - name: 'Install gems'
         run: |

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -39,13 +39,18 @@ jobs:
         ports:
           - 6379:6379
 
+    env:
+      DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
+      DATABASE_DB_TEST: boston_cas_test
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up dependencies
-        env:
-          DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
-          DATABASE_DB_TEST: boston_cas_test
+
         run: |
           apk add --no-cache \
+            nodejs yarn npm \
+            tzdata \
             git \
             bash \
             freetds-dev \
@@ -66,7 +71,6 @@ jobs:
           gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
           gem install bundler -v '< 2'
 
-      - uses: actions/checkout@v3
       - name: 'Install gems'
         run: |
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -39,18 +39,13 @@ jobs:
         ports:
           - 6379:6379
 
-    env:
-      DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
-      DATABASE_DB_TEST: boston_cas_test
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Set up dependencies
-
+        env:
+          DATABASE_WAREHOUSE_DB_TEST: test_hmis_warehouse
+          DATABASE_DB_TEST: boston_cas_test
         run: |
           apk add --no-cache \
-            nodejs yarn npm \
-            tzdata \
             git \
             bash \
             freetds-dev \
@@ -71,6 +66,7 @@ jobs:
           gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
           gem install bundler -v '< 2'
 
+      - uses: actions/checkout@v3
       - name: 'Install gems'
         run: |
           bundle install --jobs 4 --retry 3

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'composite_primary_keys', '~> 13.0'
 gem 'csv', '>= 1.0.2' # support for bom|utf-8 in ruby 2.5
 gem 'order_as_specified'
 gem 'with_advisory_lock'
-gem 'nokogiri', '>= 1.15.4' # CVE-2017-15412
+gem 'nokogiri', '>= 1.16.2' # GHSA-xc9x-jj77-9p9j
 
 gem 'autoprefixer-rails'
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,7 @@ GEM
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.19.0)
     minitest-reporters (1.5.0)
       ansi
@@ -435,7 +435,7 @@ GEM
       net-protocol
     net-ssh (7.0.1)
     nio4r (2.7.0)
-    nokogiri (1.15.4)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -477,7 +477,7 @@ GEM
     puma (6.4.2)
       nio4r (~> 2.0)
     pwned (2.0.2)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.7)
     rack-mini-profiler (3.0.0)
       rack (>= 1.2.0)
@@ -769,7 +769,7 @@ DEPENDENCIES
   minitest-reporters
   momentjs-rails (>= 2.9.0)
   net-http
-  nokogiri (>= 1.15.4)
+  nokogiri (>= 1.16.2)
   order_as_specified
   overcommit
   pagy

--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -29,6 +29,7 @@ class DeidentifiedClientsController < NonHmisClientsController
       end
 
       @non_hmis_client.current_assessment&.update_assessment_score!
+
     end
     respond_with(@non_hmis_client, location: path_for_non_hmis_client)
   end

--- a/app/models/concerns/pathways_version_four_calculations.rb
+++ b/app/models/concerns/pathways_version_four_calculations.rb
@@ -159,7 +159,7 @@ module PathwaysVersionFourCalculations
     end
 
     def transfer_title
-      'Transfer Assessment'
+      'Transfer Assessment 2024'
     end
 
     def pathways_description
@@ -1100,7 +1100,7 @@ module PathwaysVersionFourCalculations
               label: 'If yes, which ones [OPTIONAL]',
               number: '9',
               collection: {
-                _("I've faced indefinite restrictions and a history of restrictions from area shelters") => 'restrictions from area shelters', 
+                _("I've faced indefinite restrictions and a history of restrictions from area shelters") => 'restrictions from area shelters',
                 _('There have been instances where I declined to come inside during dangerous weather') => 'declined to come inside during dangerous weather',
                 _('My experience of homelessness began in Boston over 10 years ago') => 'homelessness begain 10 years ago',
                 _('I have a criminal record (CORI) or ongoing legal cases') => 'criminal record (CORI) or ongoing legal cases',

--- a/app/models/concerns/pathways_version_three_calculations.rb
+++ b/app/models/concerns/pathways_version_three_calculations.rb
@@ -148,7 +148,7 @@ module PathwaysVersionThreeCalculations
     end
 
     def transfer_title
-      'Transfer Assessment'
+      'Transfer Assessment 2021'
     end
 
     def pathways_description


### PR DESCRIPTION

[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This separates transfer assessments by year for reporting, and until we have a new transfer assessment for 2024, converts 2024 versions back into 2021, which makes more sense for reporting.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
