### PR TITLE
Add rule for matching exact number of bedrooms

### DIFF
--- a/app/models/rules/bedroom_exact.rb
+++ b/app/models/rules/bedroom_exact.rb
@@ -1,0 +1,37 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+class Rules::BedroomExact < Rule
+  def variable_requirement?
+    true
+  end
+
+  def available_number_of_bedrooms
+    [
+      [1, 'One'],
+      [2, 'Two'],
+      [3, 'Three'],
+      [4, 'Four'],
+      [5, 'Five'],
+    ]
+  end
+
+  def display_for_variable value
+    available_number_of_bedrooms.to_h.try(:[], value.to_i) || value
+  end
+
+  def clients_that_fit(scope, requirement, opportunity)
+    if Client.column_names.include?(:required_number_of_bedrooms.to_s)
+      if requirement.positive
+        scope.where(c_t[:required_number_of_bedrooms].eq(requirement.variable))
+      else
+        scope.where(c_t[:required_number_of_bedrooms].not_eq(requirement.variable))
+      end
+    else
+      raise RuleDatabaseStructureMissing.new("clients.required_number_of_bedrooms missing. Cannot check clients against #{self.class}.")
+    end
+  end
+end

--- a/app/views/admin/rules/bedroom_exacts/_bedroom_exact.haml
+++ b/app/views/admin/rules/bedroom_exacts/_bedroom_exact.haml
@@ -1,0 +1,1 @@
+= render 'rules/bedroom_exacts/bedroom_exact', bedroom_exact: bedroom_exact

--- a/app/views/rules/bedroom_exacts/_bedroom_exact.haml
+++ b/app/views/rules/bedroom_exacts/_bedroom_exact.haml
@@ -1,0 +1,3 @@
+- rule = bedroom_exact
+%h4 Number of Bedrooms
+= select_tag(:variable, options_from_collection_for_select(rule.available_number_of_bedrooms, :first, :last), class: 'variable', id: "variable_#{rule.id}", data: {options: rule.available_number_of_bedrooms.to_h.to_json})

--- a/db/rules.csv
+++ b/db/rules.csv
@@ -74,6 +74,7 @@ SsvfEligible,Supportive Services for Veterans (SSVF) Eligible,,be
 AssessmentScoreGreaterThanZero,Assessment Score greater than zero,,have
 Wheelchair,Wheelchair accessible unit,,have
 Bedroom,Minimum number of bedrooms,Fit in bedrooms,have
+BedroomExact, Exact number of bedrooms required,,have
 Occupancy,Minimum occupancy,,have
 VerifiedDisability,Verified disability,,have
 VerifiedDaysHomeless,Verified days homeless,,have


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adding a new CAS rule to match the exact number of bedrooms required

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
