### PR TITLE
TC HAT pregnancy status - always family

### DIFF
--- a/app/models/concerns/tc_hat_calculations.rb
+++ b/app/models/concerns/tc_hat_calculations.rb
@@ -60,6 +60,8 @@ module TcHatCalculations
 
     # Override family_member since the TC HAT doesn't currently ask it
     def family_member
+      # Pregnant clients are always considered a family
+      return true if pregnancy_status
       # There is a child, but the parent doesn't, and won't have custody
       return false if tc_hat_single_parent_child_over_ten && (!tc_hat_legal_custody && !tc_hat_will_gain_legal_custody)
       # Client indicated the household is adult only


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adjusts the calculation of `family_member` such that if a client has a `true` `pregnancy_status`, they are always marked as `family_member` `true`. 

## Type of change
[//]: # 'remove options that are not relevant'

- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
