### PR TITLE
include Service Provider name in match emails

### DIFF
--- a/app/views/notifications_mailer/_program_details.text.haml
+++ b/app/views/notifications_mailer/_program_details.text.haml
@@ -1,2 +1,2 @@
 Program Name: #{@match.opportunity_details.program_name.try(:html_safe)}
-Service Provider: #{@match.opportunity_details.subgrantee_name.try(:html_safe)}
+Service Provider: #{@match.opportunity_details.service_provider_name.try(:html_safe)}


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Automated match emails were showing the Service Provider name as blank. This updates the email to pull the information from the service_provider_name field.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] Bug fix

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
