### PR TITLE
Users & Agencies

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,4 +201,8 @@ class User < ApplicationRecord
   def inherited_requirements_by_source
     {}
   end
+
+  def name_with_email
+    "#{name} <#{email}>"
+  end
 end

--- a/app/views/admin/agencies/_users.haml
+++ b/app/views/admin/agencies/_users.haml
@@ -1,0 +1,40 @@
+- if @agency.users.exists?
+
+  %ul.nav.nav-tabs.mb-0
+    %li.nav-item
+      %a.nav-link.active{href: '#active', role: "presentation", data: {toggle: :tab}, aria: {controls:"active", selected:"true"}}
+        Active Users
+        .badge.badge-primary.badge-pill
+          #{@agency.users.active.count}
+    %li.nav-item
+      %a.nav-link{href: '#inactive', role: "presentation", data: {toggle: :tab}, aria: {controls:"inactive", selected:"false"}}
+        Inactive Users
+
+  .tab-content
+    .tab-pane.show.active.fade#active{role: 'tabpanel', aria: {labelledby: 'active'}}
+      %table.table.table-striped
+        %tbody
+          - @agency.users.active.each do |user|
+            %tr
+              %td= user.name_with_email
+              %td
+                = simple_form_for(:user, url: admin_agency_move_user_path(@agency)) do |f|
+                  = f.hidden_field :user_id, value: user.id
+                  .d-flex
+                    = f.input :new_agency_id, collection: Agency.all, as: :select_2, input_html: { id: "new_agency_id_for_#{user.id}"}, selected: @agency.id
+                    .mt-no-label.pt-no-label.ml-4
+                      = f.button :submit, 'Move User', class: 'btn btn-sm btn-secondary'
+
+    .tab-pane.fade#inactive{role: 'tabpanel', aria: {labelledby: 'inactive'}}
+      %table.table.table-striped
+        %tbody
+          - @agency.users.inactive.each do |user|
+            %tr
+              %td= user.name_with_email
+              %td
+                = simple_form_for(:user, url: admin_agency_move_user_path(@agency)) do |f|
+                  = f.hidden_field :user_id, value: user.id
+                  .d-flex
+                    = f.input :new_agency_id, collection: Agency.all, as: :select_2, input_html: { id: "new_agency_id_for_#{user.id}"}, selected: @agency.id
+                    .mt-no-label.pt-no-label.ml-4
+                      = f.button :submit, 'Move User', class: 'btn btn-sm btn-secondary'

--- a/app/views/admin/agencies/edit.haml
+++ b/app/views/admin/agencies/edit.haml
@@ -4,3 +4,4 @@
   Edit Agency
 
 = render 'form'
+= render 'users'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,7 +164,9 @@ Rails.application.routes.draw do
         post :stop_impersonating
       end
     end
-    resources :agencies
+    resources :agencies do
+      post :move_user
+    end
     resources :roles
     resources :versions, only: [:index]
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This exposes the users in an agency on the agency edit page and adds the ability to move users (active and inactive) between agencies.
<img width="942" alt="Screenshot 2024-04-01 at 11 56 55 AM" src="https://github.com/greenriver/boston-cas/assets/1346876/2e03dc1f-d40f-425b-aacb-8b78a83c886d">
y on the agency 

## Type of change
[//]: # 'remove options that are not relevant'

- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
