### PR TITLE
Expose move in information on match route 6

### DIFF
--- a/app/controllers/admin/match_routes_controller.rb
+++ b/app/controllers/admin/match_routes_controller.rb
@@ -42,6 +42,9 @@ module Admin
         :housing_type,
         :send_notes_by_default,
         :expects_roi,
+        :show_referral_source,
+        :show_move_in_date,
+        :show_address_field,
         prioritized_client_columns: [],
       )
     end

--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -99,11 +99,15 @@ module MatchDecisions
     end
 
     def show_address_field?
-      false
+      match_route.show_address_field
     end
 
     def show_referral_source?
-      false
+      match_route.show_referral_source
+    end
+
+    def show_move_in_date?
+      match_route.show_move_in_date
     end
 
     def started?

--- a/app/models/match_decisions/four/record_client_housed_date_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/four/record_client_housed_date_housing_subsidy_administrator.rb
@@ -102,14 +102,6 @@ module MatchDecisions::Four
       :four_record_client_housed_date_housing_subsidy_administrator
     end
 
-    def show_address_field?
-      true
-    end
-
-    def show_referral_source?
-      true
-    end
-
     class StatusCallbacks < StatusCallbacks
       def pending
       end

--- a/app/models/match_decisions/six/confirm_match_success_dnd_staff.rb
+++ b/app/models/match_decisions/six/confirm_match_success_dnd_staff.rb
@@ -7,6 +7,9 @@
 module MatchDecisions::Six
   class ConfirmMatchSuccessDndStaff < ::MatchDecisions::Base
     # validate :note_present_if_status_rejected
+    def to_partial_path
+      'match_decisions/six_confirm_match_success_dnd_staff'
+    end
 
     def statuses
       {
@@ -71,6 +74,16 @@ module MatchDecisions::Six
 
     def to_param
       :six_confirm_match_success_dnd_staff
+    end
+
+    def whitelist_params_for_update params
+      super.merge params.require(:decision).permit(
+        :building_id,
+        :unit_id,
+        :client_move_in_date,
+        :external_software_used,
+        :address,
+      )
     end
 
     private def note_present_if_status_rejected

--- a/app/views/admin/match_routes/edit.haml
+++ b/app/views/admin/match_routes/edit.haml
@@ -20,6 +20,9 @@
           = f.input :show_default_contact_types, label: 'Show the default contact types on a match'
           = f.input :send_notes_by_default, label: 'Include note content by default'
           = f.input :expects_roi, label: 'Expects ROI'
+          = f.input :show_referral_source, label: 'Show the referral source checkbox?'
+          = f.input :show_move_in_date, label: 'Include move-in date collection?'
+          = f.input :show_address_field, label: 'Include address collection?'
           = f.association :match_prioritization, collection: MatchPrioritization::Base.prioritization_schemes.map {|prioritization_scheme| [prioritization_scheme.title, prioritization_scheme.first.id]}, label_method: :first, value_method: :second, include_blank: false, input_html: { class: :select2 }
           = f.input :stalled_interval, collection: @route.stall_intervals, label: "Days until a match is considered stalled", input_html: { class: :select2 }
           = f.association :tag, include_blank: 'Optional Tag', input_html: { class: :select2 }, hint: 'Assigning a tag is required if the route is prioritized by rank.'

--- a/app/views/match_decisions/_client_move_in_details.haml
+++ b/app/views/match_decisions/_client_move_in_details.haml
@@ -21,13 +21,13 @@
           input_html: {class: 'unit', data: {dependent: true, url: '/buildings/:id/available_move_in_units.json', 'value-method' => :id, 'label-method' => :name, default_parent_id: default_building_id, default_value: default_unit_id, default_label: default_unit_name}}
   %hr
 %div
-  %p
-    Please record the date the client moved in.
-  .row
-    .col-md-6
-      = form.input :client_move_in_date, label: Translation.translate('Lease start date'), as: :date_picker, disabled: !@decision.editable?
-  .form-inputs
-    = form.input :note, as: :text, input_html: {rows: 4, disabled: !@decision.editable?}
+  - if @decision.show_move_in_date?
+    %p Please record the date the client moved in.
+    .row
+      .col-md-6
+        = form.input :client_move_in_date, label: Translation.translate('Lease start date'), as: :date_picker, disabled: !@decision.editable?
+    .form-inputs
+      = form.input :note, as: :text, input_html: {rows: 4, disabled: !@decision.editable?}
   %p
     = "#{Translation.translate('DND')} and the #{Translation.translate('Shelter Agency')} contact will receive notification of the housing date."
   - if @decision.show_referral_source?

--- a/app/views/match_decisions/_six_confirm_match_success_dnd_staff.haml
+++ b/app/views/match_decisions/_six_confirm_match_success_dnd_staff.haml
@@ -1,0 +1,29 @@
+.match-decision.c-card.c-card--flush.card--block
+  .c-card__content
+    = simple_form_for @decision, url: access_context.match_decision_path(@match, @decision) do |form|
+      .o-pre-choose
+        .form-inputs
+          .row
+            .col-md-6
+              = form.input :note, as: :text, input_html: {rows: 4, disabled: !(@decision.editable?)}
+      .o-choose.o-choose--flush
+        .o-choose__choice{class: ('o-choose__choice--disabled' if !@decision.editable?)}
+          %header
+            .o-choose__title
+              .c-choice-icon.c-choice-icon--confirm.mr-4
+              %h3 Confirm Match
+          .o-choose__content
+            %p Confirming match success will complete the match and remove the client and voucher/unit from future matching.
+            - if @decision.accessible_by?(current_contact)
+              - if @decision.show_referral_source?
+                = form.input :external_software_used, label: Translation.translate('Did you or this client use external software to help with housing?'), as: :boolean, disabled: !@decision.editable?
+              - if @decision.show_move_in_date?
+                %p Please record the date the client moved in.
+                .row
+                  .col-md-6
+                    = form.input :client_move_in_date, label: Translation.translate('Lease start date'), as: :date_picker, disabled: !@decision.editable?
+              - if @decision.show_address_field? && !has_unit?
+                = form.input :address, label: Translation.translate('Address of housing'), as: :text, disabled: !@decision.editable?
+            -# = form.submit 'Confirm Match Success', class: 'btn btn-success', data: {submit_param_name: 'decision[status]', submit_param_value: 'confirmed'}, disabled: !(@decision.editable?)
+            = render 'match_decisions/continue_button', text: 'Confirm Match Success', icon: 'checkmark', button_attributes: { class: 'btn btn-success', data: {submit_param_name: 'decision[status]', submit_param_value: 'confirmed'}, disabled: !(@decision.editable?) }
+        = render 'match_decisions/reject_actions', form: form

--- a/db/migrate/20240405165545_add_address_config_to_routes.rb
+++ b/db/migrate/20240405165545_add_address_config_to_routes.rb
@@ -1,0 +1,9 @@
+class AddAddressConfigToRoutes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :match_routes, :show_referral_source, :boolean, default: false
+    add_column :match_routes, :show_move_in_date, :boolean, default: false
+    add_column :match_routes, :show_address_field, :boolean, default: false
+
+    MatchRoutes::Four.update_all(show_address_field: true, show_referral_source: true, show_move_in_date: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_05_213939) do
+ActiveRecord::Schema.define(version: 2024_04_05_165545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -745,6 +745,9 @@ ActiveRecord::Schema.define(version: 2024_03_05_213939) do
     t.boolean "send_notes_by_default", default: false, null: false
     t.boolean "expects_roi", default: true
     t.text "prioritized_client_columns"
+    t.boolean "show_referral_source", default: false
+    t.boolean "show_move_in_date", default: false
+    t.boolean "show_address_field", default: false
     t.index ["tag_id"], name: "index_match_routes_on_tag_id"
   end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This adds three fields to the final step of Match Route 6

1. Show Referral Source
2. Show Move in date
3. Show Address

And makes the display of these three items configurable on both route 4 (where they are visible) and 6 where they were not.

**Config is now available for these three options**
<img width="536" alt="Screenshot 2024-04-05 at 2 06 05 PM" src="https://github.com/greenriver/boston-cas/assets/1346876/108da13f-3ba2-449d-ae4b-b5f79c6292a3">

**Enabling the config will expose those questions on the step**
<img width="585" alt="Screenshot 2024-04-05 at 2 06 17 PM" src="https://github.com/greenriver/boston-cas/assets/1346876/99b15871-5c58-4775-b284-8305c84bed69">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
