### PR TITLE
Carrierwave updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.1)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.4.1)
       sshkit (>= 1.6.1, != 1.7.0)
@@ -222,7 +222,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    carrierwave (3.0.5)
+    carrierwave (3.0.7)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
       addressable (~> 2.6)
@@ -253,7 +253,7 @@ GEM
     coffee-script-source (1.12.2)
     composite_primary_keys (13.0.4)
       activerecord (~> 6.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.3.0)
     crass (1.0.6)
     csv (3.2.6)
@@ -297,7 +297,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.0.0)
       i18n (>= 1.8.11, < 2)
-    ffi (1.15.5)
+    ffi (1.16.3)
     font-awesome-sass (6.2.1)
       sassc (~> 2.0)
     foreman (0.87.2)
@@ -339,7 +339,7 @@ GEM
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
     htmlentities (4.3.4)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     image_processing (1.12.2)
@@ -386,7 +386,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     marginalia (1.11.1)
       actionpack (>= 5.2)
       activerecord (>= 5.2)
@@ -398,7 +398,7 @@ GEM
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.5)
-    minitest (5.19.0)
+    minitest (5.22.3)
     minitest-reporters (1.5.0)
       ansi
       builder
@@ -459,7 +459,7 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.1)
+    public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
     pwned (2.0.2)
@@ -572,7 +572,7 @@ GEM
       rexml
     ruby-prof (1.5.0)
     ruby-progressbar (1.11.0)
-    ruby-vips (2.2.0)
+    ruby-vips (2.2.1)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     ruby_parser (3.19.2)
@@ -656,7 +656,7 @@ GEM
       zip_tricks (>= 4.5, < 6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.13)
     zip_tricks (5.6.0)
 
 PLATFORMS


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Fix for CVE-2024-29034

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Dependency update
