### PR TITLE
Add cancelations options to step 1

### DIFF
--- a/app/models/match_decision_reasons/base.rb
+++ b/app/models/match_decision_reasons/base.rb
@@ -33,7 +33,7 @@ module MatchDecisionReasons
     end
 
     def other?
-      false
+      name == 'Other'
     end
 
     def not_working_with_client?

--- a/app/views/match_decisions/_hsa_acknowledges_receipt.haml
+++ b/app/views/match_decisions/_hsa_acknowledges_receipt.haml
@@ -14,4 +14,21 @@
                 %div{data: {acknowledge_href: access_context.match_decision_acknowledgment_path(@match, @decision)}}
                 = render 'match_decisions/continue_button', text: 'Acknowledge Receipt of Match Details', icon: 'checkmark', button_attributes: { class: 'btn btn-success', data: {submit_param_name: 'decision[status]', submit_param_value: 'acknowledged'}, disabled: !(@decision.editable?) }
           - if can_delete_matches?
-            = render 'match_decisions/destroy_actions', form: form
+            .o-choose__choice
+              %header.jMatchHeader
+                %ul.o-choose__nav.nav.jMatchActionNav
+                  = render 'match_decisions/cancel_tab', active_tab: 'active'
+                  = render 'match_decisions/park_tab'
+                  = render 'match_decisions/destroy_tab'
+              .o-choose__content
+                .tab-content
+                  - cancel_data = {submit_param_name: 'decision[status]', submit_param_value: 'canceled'}
+                  = render 'match_decisions/cancel_tab_content', form: form, cancel_data: cancel_data, active_tab: 'active'
+                  = render 'match_decisions/park_tab_content', form: form, cancel_data: cancel_data
+                  = render 'match_decisions/destroy_tab_content', form: form
+
+            = content_for :page_js do
+              :javascript
+                new App.Matches.ActionNav('.jMatchHeader')
+
+            = render 'match_decisions/cancel_and_park_js'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This adds the ability to cancel/park from the first step in the provider only route.
<img width="1101" alt="Screenshot 2024-04-16 at 2 08 12 PM" src="https://github.com/greenriver/boston-cas/assets/1346876/5817e0ff-88b5-4225-8842-2fbb4b09c270">

## Type of change
[//]: # 'remove options that are not relevant'

- [x] New feature (adds functionality)


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
