### PR TITLE
Remove identifying information from the deidentified pathways 2024 assessment

### DIFF
--- a/app/models/concerns/pathways_version_four_calculations.rb
+++ b/app/models/concerns/pathways_version_four_calculations.rb
@@ -465,7 +465,9 @@ module PathwaysVersionFourCalculations
     def form_fields
       case title
       when pathways_title
-        pathways_form_fields
+        pathways_fields = pathways_form_fields
+        pathways_fields = deidentify_form_fields(pathways_fields) unless identified?
+        pathways_fields
       when transfer_title
         transfer_form_fields
       else
@@ -475,6 +477,12 @@ module PathwaysVersionFourCalculations
 
     def picker_form_fields
       []
+    end
+
+    def deidentify_form_fields(form_fields)
+      # Remove the fields with identifying information from the form
+      identifying_fields = [:phone_number, :email_addresses]
+      form_fields.except(*identifying_fields)
     end
 
     def transfer_form_fields


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

FIlter out the 2C "Client Phone Number" and 2D "Client email" from the deidentified client 2024 pathways assessment. These fields will remain in the identified client assessment.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
