### PR TITLE
Allow automatic parking of configed routes for active and successful matches

### DIFF
--- a/app/controllers/admin/match_routes_controller.rb
+++ b/app/controllers/admin/match_routes_controller.rb
@@ -46,6 +46,8 @@ module Admin
         :show_move_in_date,
         :show_address_field,
         prioritized_client_columns: [],
+        routes_parked_on_active_match: [],
+        routes_parked_on_successful_match: [],
       )
     end
 

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -456,6 +456,10 @@ class Client < ApplicationRecord
     available
   end
 
+  def unavailable_fors_include_active_match
+    unavailable_as_candidate_fors.detect { |uf| uf.reason == UnavailableAsCandidateFor::ACTIVE_MATCH_TEXT }.present?
+  end
+
   def available_text
     if is_available_for_matching?
       if available_as_candidate_for_any_route?

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -456,7 +456,7 @@ class Client < ApplicationRecord
     available
   end
 
-  def unavailable_fors_include_active_match
+  def unavailable_fors_include_active_match?
     unavailable_as_candidate_fors.detect { |uf| uf.reason == UnavailableAsCandidateFor::ACTIVE_MATCH_TEXT }.present?
   end
 

--- a/app/models/match_routes/base.rb
+++ b/app/models/match_routes/base.rb
@@ -8,6 +8,8 @@ module MatchRoutes
   class Base < ApplicationRecord
     self.table_name = :match_routes
     serialize :prioritized_client_columns, Array
+    serialize :routes_parked_on_active_match, Array
+    serialize :routes_parked_on_successful_match, Array
 
     belongs_to :match_prioritization, class_name: MatchPrioritization::Base.name, foreign_key: :match_prioritization_id, primary_key: :id
     belongs_to :tag if column_names.include?('tag_id')

--- a/app/views/admin/match_routes/edit.haml
+++ b/app/views/admin/match_routes/edit.haml
@@ -27,6 +27,8 @@
           = f.input :stalled_interval, collection: @route.stall_intervals, label: "Days until a match is considered stalled", input_html: { class: :select2 }
           = f.association :tag, include_blank: 'Optional Tag', input_html: { class: :select2 }, hint: 'Assigning a tag is required if the route is prioritized by rank.'
           = f.input :prioritized_client_columns, collection: Client.prioritized_columns_data.map { |column| [column.last[:title], column.first] }.sort, label: 'Prioritized Client Columns', input_html: { class: :select2, multiple: true }
+          = f.input :routes_parked_on_active_match, collection: MatchRoutes::Base.all.map { |route| [route.title, route.class] }.sort , label: 'Routes to park a client on an active match', input_html: { class: :select2, multiple: true }
+          = f.input :routes_parked_on_successful_match, collection: MatchRoutes::Base.all.map { |route| [route.title, route.class] }.sort , label: 'Routes to park a client after a successful match', input_html: { class: :select2, multiple: true }
           = f.button :submit, value: "Update #{@route.title}"
   .col-md-6
     .c-card

--- a/app/views/clients/_availability_status.haml
+++ b/app/views/clients/_availability_status.haml
@@ -10,7 +10,7 @@
 - if @client.unavailable_as_candidate_fors.exists?
   .blocked-on-routes
     %p.m-2.mt-4.muted-text
-      - if @client.unavailable_fors_include_active_match
+      - if @client.unavailable_fors_include_active_match?
         %em Clients are blocked from matching while actively in a resource match.
       - else
         - if UnavailableAsCandidateFor.expiration_length.positive?

--- a/app/views/clients/_availability_status.haml
+++ b/app/views/clients/_availability_status.haml
@@ -10,9 +10,12 @@
 - if @client.unavailable_as_candidate_fors.exists?
   .blocked-on-routes
     %p.m-2.mt-4.muted-text
-      - if UnavailableAsCandidateFor.expiration_length.positive?
-        %em Clients are blocked from matching on the same route for #{UnavailableAsCandidateFor.describe_expiration_length} after a complete and successful match.
+      - if @client.unavailable_fors_include_active_match
+        %em Clients are blocked from matching while actively in a resource match.
       - else
+        - if UnavailableAsCandidateFor.expiration_length.positive?
+          %em Clients are blocked from matching on the same route for #{UnavailableAsCandidateFor.describe_expiration_length} after a complete and successful match.
+        - else
         %em Clients are blocked from matching on the same route after a complete and successful match.
     %p.m-2.mt-4.muted-text
       %em #{@client.name} will not match any vacancies on the following routes:

--- a/db/migrate/20240708180516_add_match_route_parking_columns.rb
+++ b/db/migrate/20240708180516_add_match_route_parking_columns.rb
@@ -1,0 +1,6 @@
+class AddMatchRouteParkingColumns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :match_routes, :routes_parked_on_active_match, :text
+    add_column :match_routes, :routes_parked_on_successful_match, :text
+  end
+end

--- a/db/migrate/20240708180516_add_match_route_parking_columns.rb
+++ b/db/migrate/20240708180516_add_match_route_parking_columns.rb
@@ -2,5 +2,18 @@ class AddMatchRouteParkingColumns < ActiveRecord::Migration[7.0]
   def change
     add_column :match_routes, :routes_parked_on_active_match, :text
     add_column :match_routes, :routes_parked_on_successful_match, :text
+
+    MatchRoutes::Base.all.each do |route| 
+      success_route_array = if route.should_cancel_other_matches
+        MatchRoutes::Base.all.map {|r| r.class.to_s }
+      else
+        [route.class.to_s]
+      end
+      active_route_array = [route.class.to_s] if route.should_prevent_multiple_matches_per_client
+      route.update(
+        routes_parked_on_successful_match: success_route_array,
+        routes_parked_on_active_match: active_route_array,
+        )
+    end  
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_10_185742) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_08_180516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -753,6 +753,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_185742) do
     t.boolean "show_referral_source", default: false
     t.boolean "show_move_in_date", default: false
     t.boolean "show_address_field", default: false
+    t.text "routes_parked_on_active_match"
+    t.text "routes_parked_on_successful_match"
     t.index ["tag_id"], name: "index_match_routes_on_tag_id"
   end
 

--- a/spec/integration/match_engine_spec.rb
+++ b/spec/integration/match_engine_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'Running the match engine...', type: :request do
   let(:route) do
     r = MatchRoutes::Default.first
     r.update(match_prioritization_id: priority.id)
+    r.update(routes_parked_on_active_match: [r.class.name])
     r
   end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add routes to park on active and successful matches to the match route configurations. On a match being active or successful, park the routes specified in the config for the corresponding event. Similarly, if an active route is no longer active (canceled/rejected/poached) unpark the routes that were parked due to the match becoming active.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
