### PR TITLE
Add a note to stalled matches when trying to submit an overall match note

### DIFF
--- a/app/views/match_notes/_form.haml
+++ b/app/views/match_notes/_form.haml
@@ -2,7 +2,7 @@
 - contact_list = @match.grouped_contact_list
 .note-form
   = simple_form_for @match_note, url: match_notes_path(@match, match_note_referrer_params), as: :match_note, data: data do |form|
-    = form.input :note, as: :text, input_html: {rows: 4}, label: false
+    = form.input :note, as: :text, input_html: {rows: 4}, label: 'Note contents'
     - if @match.can_create_administrative_note?(access_context.current_contact)
       = form.input :admin_note, label: 'Administrative note?', hint: 'If checked, this note will only be visible to users who create notes like this one.  Generally this permission is only given to administrators.'
     - if @match.can_create_administrative_note?(access_context.current_contact) || current_user.can_send_notes_via_email?

--- a/app/views/match_notes/new.haml
+++ b/app/views/match_notes/new.haml
@@ -1,4 +1,6 @@
 = content_for :modal_title do
   Add Overall Match Note
-
+- if @match.current_decision&.stallable? && @match.stalled?
+  .alert.alert-warning
+    #{Translation.translate('This match is currently stalled.  Adding a note here will not submit a status update.  If you arrived here intending to submit a status update, please fill in the form under the Match Stalled heading.')}
 = render 'form'


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This change alerts someone who is submitting an overall note for a stalled match.
<img width="513" alt="Screenshot 2024-09-09 at 8 51 00 AM" src="https://github.com/user-attachments/assets/4313de5c-cd8a-4d62-82e0-c671a68db10c">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
