### PR TITLE
Hotfix for what steps are editable

### DIFF
--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -86,7 +86,7 @@ module MatchDecisions
     def editable?
       # can this decision be updated by a notification response?
       # override this default behavior in subclasses
-      initialized? && match_open? && saved_status !~ /\A(acknowledged|accepted|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
+      initialized? && match_open? && saved_status !~ /\A(accepted|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
     end
 
     def expires?


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

This removes `acknowledged` from a status that is considered un-editable.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
