### PR TITLE
Add 'Primary Option' for each contact type on Matches

### DIFF
--- a/app/controllers/match_contacts_controller.rb
+++ b/app/controllers/match_contacts_controller.rb
@@ -22,72 +22,116 @@ class MatchContactsController < ApplicationController
   def update
     update_params = match_contacts_params
     saved = @match_contacts.update(update_params)
-    unless request.xhr?
-      if saved
-        flash[:notice] = "Match Contacts updated"
-        redirect_to match_path(@match)
-      else
-        raise @match_contacts.errors.full_messages.inspect
-        flash[:error] = "Please review the form problems below."
-        redirect_to :edit
-      end
+    return if request.xhr?
+
+    if saved
+      flash[:notice] = 'Match Contacts updated'
+      redirect_to match_path(@match)
+    else
+      raise @match_contacts.errors.full_messages.inspect
+      flash[:error] = 'Please review the form problems below.' # rubocop:disable Lint/UnreachableCode
+      redirect_to :edit
     end
+  end
+
+  def reorder
+    return unless params[:join_contact]
+
+    order_number = 1 # Default to setting the contact as primary
+    order_number = params[:order_number].to_i if params[:order_number]
+    set_contact_order(params[:join_contact], order_number)
+    redirect_to match_path(@match)
   end
 
   private
 
-    def match_scope
-      ClientOpportunityMatch.all
+  def set_contact_order(update_contact, order_number = 1)
+    join_contact = match.client_opportunity_match_contacts.find(update_contact)
+    contact_type = nil
+    match_contact_methods.each do |type, _|
+      contact_type = type if join_contact.send(type)
     end
 
-    def set_match
-      @match = match_scope.find params[:match_id]
+    # We currently only want one contact per order number, so strip order status for any other contacts in the group
+    a_t = ClientOpportunityMatchContact.arel_table
+    contacts = @match.client_opportunity_match_contacts.where(a_t[contact_type].eq(true)).where(contact_order: order_number)
+    contacts.each do |contact|
+      contact.contact_order = nil
+      contact.save
     end
 
-    def set_current_contact
-      @current_contact = current_contact
-    end
+    # Set the selected contact as ordered contact
+    join_contact.contact_order = order_number
+    join_contact.save
+  end
 
-    def set_match_contacts
-      @match_contacts = @match.match_contacts
-    end
+  def match_contact_methods
+    @match_contact_methods ||= {
+      shelter_agency: :shelter_agency_contacts,
+      client: :client_contacts,
+      dnd_staff: :dnd_staff_contacts,
+      housing_subsidy_admin: :housing_subsidy_admin_contacts,
+      ssp: :ssp_contacts,
+      hsp: :hsp_contacts,
+      do: :do_contacts,
+    }
+  end
 
-    def match_contacts_params
-      base_params = params[:match_contacts] || ActionController::Parameters.new
-      base_params.permit(
-        shelter_agency_contact_ids: [],
-        housing_subsidy_admin_contact_ids: [],
-        dnd_staff_contact_ids: [],
-        client_contact_ids: [],
-        ssp_contact_ids: [],
-        hsp_contact_ids: [],
-        do_contact_ids: [],
-      ).tap do |result|
-        if current_contact.user_can_edit_match_contacts?
-          result[:shelter_agency_contact_ids] ||= []
-          result[:client_contact_ids] ||= []
-          result[:dnd_staff_contact_ids] ||= []
-          result[:housing_subsidy_admin_contact_ids] ||= []
-          result[:ssp_contact_ids] ||= []
-          result[:hsp_contact_ids] ||= []
-          result[:do_contact_ids] ||= []
-        elsif hsa_can_edit_contacts?
-          # only allow editing of the hsa contacts
-          result[:shelter_agency_contact_ids] = @match.shelter_agency_contact_ids
-          result[:client_contact_ids] = @match.client_contact_ids
-          result[:dnd_staff_contact_ids] = @match.dnd_staff_contact_ids
-          result[:housing_subsidy_admin_contact_ids] ||= []
-          result[:ssp_contact_ids] = @match.ssp_contact_ids
-          result[:hsp_contact_ids] = @match.hsp_contact_ids
-          result[:do_contact_ids] = @match.do_contact_ids
-          # always add self
-          result[:housing_subsidy_admin_contact_ids] << current_contact.id unless result[:housing_subsidy_admin_contact_ids].map(&:to_i).include? current_contact.id
-        end
+  def match_contacts_method_for input_name
+    match_contact_methods[input_name] || input_name
+  end
+
+  def match_scope
+    ClientOpportunityMatch.all
+  end
+
+  def set_match
+    @match = match_scope.find params[:match_id]
+  end
+
+  def set_current_contact
+    @current_contact = current_contact
+  end
+
+  def set_match_contacts
+    @match_contacts = @match.match_contacts
+  end
+
+  def match_contacts_params
+    base_params = params[:match_contacts] || ActionController::Parameters.new
+    base_params.permit(
+      shelter_agency_contact_ids: [],
+      housing_subsidy_admin_contact_ids: [],
+      dnd_staff_contact_ids: [],
+      client_contact_ids: [],
+      ssp_contact_ids: [],
+      hsp_contact_ids: [],
+      do_contact_ids: [],
+    ).tap do |result|
+      if current_contact.user_can_edit_match_contacts?
+        result[:shelter_agency_contact_ids] ||= []
+        result[:client_contact_ids] ||= []
+        result[:dnd_staff_contact_ids] ||= []
+        result[:housing_subsidy_admin_contact_ids] ||= []
+        result[:ssp_contact_ids] ||= []
+        result[:hsp_contact_ids] ||= []
+        result[:do_contact_ids] ||= []
+      elsif hsa_can_edit_contacts?
+        # only allow editing of the hsa contacts
+        result[:shelter_agency_contact_ids] = @match.shelter_agency_contact_ids
+        result[:client_contact_ids] = @match.client_contact_ids
+        result[:dnd_staff_contact_ids] = @match.dnd_staff_contact_ids
+        result[:housing_subsidy_admin_contact_ids] ||= []
+        result[:ssp_contact_ids] = @match.ssp_contact_ids
+        result[:hsp_contact_ids] = @match.hsp_contact_ids
+        result[:do_contact_ids] = @match.do_contact_ids
+        # always add self
+        result[:housing_subsidy_admin_contact_ids] << current_contact.id unless result[:housing_subsidy_admin_contact_ids].map(&:to_i).include? current_contact.id
       end
     end
+  end
 
-    def require_current_contact_can_edit_match_contacts!
-      not_authorized! unless current_contact.user_can_edit_match_contacts? || hsa_can_edit_contacts?
-    end
-
+  def require_current_contact_can_edit_match_contacts!
+    not_authorized! unless current_contact.user_can_edit_match_contacts? || hsa_can_edit_contacts?
+  end
 end

--- a/app/controllers/match_contacts_controller.rb
+++ b/app/controllers/match_contacts_controller.rb
@@ -40,6 +40,11 @@ class MatchContactsController < ApplicationController
     order_number = 1 # Default to setting the contact as primary
     order_number = params[:order_number].to_i if params[:order_number]
     set_contact_order(params[:join_contact], order_number)
+    set_match
+    set_match_contacts
+    # byebug
+    return if request.xhr?
+
     redirect_to match_path(@match)
   end
 

--- a/app/controllers/match_contacts_controller.rb
+++ b/app/controllers/match_contacts_controller.rb
@@ -59,8 +59,7 @@ class MatchContactsController < ApplicationController
       end
 
       # We currently only want one contact per order number, so strip order status for any other contacts in the group
-      a_t = ClientOpportunityMatchContact.arel_table
-      @match.client_opportunity_match_contacts.where(a_t[contact_type].eq(true)).where(contact_order: order_number).update_all(contact_order: nil)
+      @match.client_opportunity_match_contacts.where(contact_type => true, contact_order: order_number).update_all(contact_order: nil)
 
       # Set the selected contact as ordered contact
       join_contact.contact_order = order_number

--- a/app/models/client_contact.rb
+++ b/app/models/client_contact.rb
@@ -5,11 +5,41 @@
 ###
 
 class ClientContact < ApplicationRecord
-
   belongs_to :client, inverse_of: :client_contacts
   belongs_to :contact, inverse_of: :client_contacts
 
   acts_as_paranoid
   has_paper_trail
 
+  def self.contact_types
+    [
+      :regular,
+      :shelter_agency,
+      :dnd_staff,
+      :housing_subsidy_admin,
+      :ssp,
+      :hsp,
+      :do,
+    ].freeze
+  end
+
+  def self.contact_type_columns
+    contact_types.map { |t| ["#{t}_contacts".to_sym, t] }.to_h
+  end
+
+  def self.available_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "available_#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.available_contact_method_for(contact_type)
+    available_contact_methods[contact_type] || contact_type
+  end
+
+  def self.selected_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.selected_contact_method_for(contact_type)
+    selected_contact_methods[contact_type] || contact_type
+  end
 end

--- a/app/models/client_contacts.rb
+++ b/app/models/client_contacts.rb
@@ -101,15 +101,7 @@ class ClientContacts
   end
 
   def self.input_names
-    [
-      :regular_contacts,
-      :shelter_agency_contacts,
-      :dnd_staff_contacts,
-      :housing_subsidy_admin_contacts,
-      :ssp_contacts,
-      :hsp_contacts,
-      :do_contacts,
-    ]
+    ClientContact.contact_type_columns.keys
   end
 
   def input_names
@@ -117,28 +109,10 @@ class ClientContacts
   end
 
   def available_contacts_method_for input_name
-    @available_contacts_methods ||= {
-      shelter_agency_contacts: :available_shelter_agency_contacts,
-      regular_contacts: :available_regular_contacts,
-      dnd_staff_contacts: :available_dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :available_housing_subsidy_admin_contacts,
-      ssp_contacts: :available_ssp_contacts,
-      hsp_contacts: :available_hsp_contacts,
-      do_contacts: :available_do_contacts,
-    }
-    @available_contacts_methods[input_name] || input_name
+    ClientContact.available_contact_method_for(input_name)
   end
 
   def selected_contacts_method_for input_name
-    @selected_contacts_methods ||= {
-      shelter_agency_contacts: :shelter_agency_contacts,
-      regular_contacts: :regular_contacts,
-      dnd_staff_contacts: :dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :housing_subsidy_admin_contacts,
-      ssp_contacts: :ssp_contacts,
-      hsp_contacts: :hsp_contacts,
-      do_contacts: :do_contacts,
-    }
-    @selected_contacts_methods[input_name] || input_name
+    ClientContact.selected_contact_method_for(input_name)
   end
 end

--- a/app/models/client_opportunity_match_contact.rb
+++ b/app/models/client_opportunity_match_contact.rb
@@ -18,7 +18,7 @@ class ClientOpportunityMatchContact < ApplicationRecord
 
   scope :for_contact_type, ->(contact_type) do
     contact_type_column = ClientOpportunityMatchContact.column_for(contact_type)
-    where(ClientOpportunityMatchContact.arel_table[contact_type_column.to_sym].eq(true))
+    where(contact_type_column => true)
   end
 
   def self.text_search(text)

--- a/app/models/client_opportunity_match_contact.rb
+++ b/app/models/client_opportunity_match_contact.rb
@@ -20,10 +20,9 @@ class ClientOpportunityMatchContact < ApplicationRecord
     return none unless text.present?
 
     contact_matches = Contact.where(
-      Contact.arel_table[:id].eq(arel_table[:contact_id])
+      Contact.arel_table[:id].eq(arel_table[:contact_id]),
     ).text_search(text).arel.exists
 
     where(contact_matches)
   end
-
 end

--- a/app/models/client_opportunity_match_contact.rb
+++ b/app/models/client_opportunity_match_contact.rb
@@ -58,4 +58,20 @@ class ClientOpportunityMatchContact < ApplicationRecord
   def self.join_method_for(contact_type)
     join_contact_methods[contact_type] || contact_type
   end
+
+  def self.available_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "available_#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.available_contact_method_for(contact_type)
+    available_contact_methods[contact_type] || contact_type
+  end
+
+  def self.selected_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.selected_contact_method_for(contact_type)
+    selected_contact_methods[contact_type] || contact_type
+  end
 end

--- a/app/models/client_opportunity_match_contact.rb
+++ b/app/models/client_opportunity_match_contact.rb
@@ -16,6 +16,11 @@ class ClientOpportunityMatchContact < ApplicationRecord
 
   acts_as_paranoid
 
+  scope :for_contact_type, ->(contact_type) do
+    contact_type_column = ClientOpportunityMatchContact.column_for(contact_type)
+    where(ClientOpportunityMatchContact.arel_table[contact_type_column.to_sym].eq(true))
+  end
+
   def self.text_search(text)
     return none unless text.present?
 
@@ -24,5 +29,33 @@ class ClientOpportunityMatchContact < ApplicationRecord
     ).text_search(text).arel.exists
 
     where(contact_matches)
+  end
+
+  def self.contact_types
+    [
+      :shelter_agency,
+      :client,
+      :dnd_staff,
+      :housing_subsidy_admin,
+      :ssp,
+      :hsp,
+      :do,
+    ].freeze
+  end
+
+  def self.contact_type_columns
+    contact_types.map { |t| ["#{t}_contacts".to_sym, t] }.to_h
+  end
+
+  def self.column_for(contact_type)
+    contact_type_columns[contact_type] || contact_type
+  end
+
+  def self.join_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "#{t}_join_contacts".to_sym] }.to_h
+  end
+
+  def self.join_method_for(contact_type)
+    join_contact_methods[contact_type] || contact_type
   end
 end

--- a/app/models/concerns/contact_join_model.rb
+++ b/app/models/concerns/contact_join_model.rb
@@ -14,15 +14,15 @@ module ContactJoinModel
   extend ActiveSupport::Concern
 
   included do
-    delegate :full_name, :email, :phone, :role,
-    to: :contact, allow_nil: true, prefix: true
+    delegate :full_name, :email, :phone, :role, :contact_order,
+             to: :contact, allow_nil: true, prefix: true
 
     accepts_nested_attributes_for :contact
 
     def self.model_name
       # really just needed for route_key
       # keeps standard naming but uses 'contact' for routes
-      @_model_name ||= ActiveModel::Name.new(self, nil, to_s.demodulize.underscore).tap do |model_name|
+      @model_name ||= ActiveModel::Name.new(self, nil, to_s.demodulize.underscore).tap do |model_name|
         model_name.instance_variable_set(:@route_key, 'contacts')
         model_name.instance_variable_set(:@singular_route_key, 'contact')
       end

--- a/app/models/concerns/related_default_contacts.rb
+++ b/app/models/concerns/related_default_contacts.rb
@@ -13,6 +13,9 @@ module RelatedDefaultContacts
     Contact.active_contacts
   end
 
+  def contact_order
+  end
+
   def available_shelter_agency_contacts
     contact_scope.where.not(id: shelter_agency_contact_ids)
   end

--- a/app/models/concerns/reporting/filter_scopes.rb
+++ b/app/models/concerns/reporting/filter_scopes.rb
@@ -98,7 +98,7 @@ module Reporting::FilterScopes
     private def filter_for_contact_order(scope)
       return scope if @filter.contact_order.blank? || @filter.contact_order.zero?
 
-      scope.contacts_in_order(@filter.contacts.map(&:to_s), @filter.contact_order)
+      scope.contacts_with_order_value(@filter.contacts.map(&:to_s), @filter.contact_order)
     end
   end
 end

--- a/app/models/concerns/reporting/filter_scopes.rb
+++ b/app/models/concerns/reporting/filter_scopes.rb
@@ -94,5 +94,11 @@ module Reporting::FilterScopes
 
       scope.contacts_in_type(@filter.contacts.map(&:to_s), @filter.contact_type)
     end
+
+    private def filter_for_contact_order(scope)
+      return scope if @filter.contact_order.blank? || @filter.contact_order.zero?
+
+      scope.contacts_in_order(@filter.contacts.map(&:to_s), @filter.contact_order)
+    end
   end
 end

--- a/app/models/concerns/updateable_attributes.rb
+++ b/app/models/concerns/updateable_attributes.rb
@@ -18,5 +18,4 @@ module UpdateableAttributes
     assign_attributes attrs
     save
   end
-
 end

--- a/app/models/match_contacts.rb
+++ b/app/models/match_contacts.rb
@@ -145,28 +145,10 @@ class MatchContacts
   end
 
   def available_contacts_method_for input_name
-    @available_contacts_methods ||= {
-      shelter_agency_contacts: :available_shelter_agency_contacts,
-      client_contacts: :available_client_contacts,
-      dnd_staff_contacts: :available_dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :available_housing_subsidy_admin_contacts,
-      ssp_contacts: :available_ssp_contacts,
-      hsp_contacts: :available_hsp_contacts,
-      do_contacts: :available_do_contacts,
-    }
-    @available_contacts_methods[input_name] || input_name
+    ClientOpportunityMatchContact.available_contact_method_for(input_name)
   end
 
   def selected_contacts_method_for input_name
-    @selected_contacts_methods ||= {
-      shelter_agency_contacts: :shelter_agency_contacts,
-      client_contacts: :client_contacts,
-      dnd_staff_contacts: :dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :housing_subsidy_admin_contacts,
-      ssp_contacts: :ssp_contacts,
-      hsp_contacts: :hsp_contacts,
-      do_contacts: :do_contacts,
-    }
-    @selected_contacts_methods[input_name] || input_name
+    ClientOpportunityMatchContact.selected_contact_method_for(input_name)
   end
 end

--- a/app/models/match_contacts.rb
+++ b/app/models/match_contacts.rb
@@ -133,15 +133,7 @@ class MatchContacts
   end
 
   def self.input_names
-    [
-      :shelter_agency_contacts,
-      :dnd_staff_contacts,
-      :housing_subsidy_admin_contacts,
-      :ssp_contacts,
-      :hsp_contacts,
-      :do_contacts,
-      :client_contacts,
-    ]
+    ClientOpportunityMatchContact.contact_type_columns.keys
   end
 
   def input_names
@@ -149,16 +141,7 @@ class MatchContacts
   end
 
   def join_contacts_method_for input_name
-    @join_contacts_method_for ||= {
-      shelter_agency_contacts: :shelter_agency_join_contacts,
-      client_contacts: :client_join_contacts,
-      dnd_staff_contacts: :dnd_staff_join_contacts,
-      housing_subsidy_admin_contacts: :housing_subsidy_admin_join_contacts,
-      ssp_contacts: :ssp_join_contacts,
-      hsp_contacts: :hsp_join_contacts,
-      do_contacts: :do_join_contacts,
-    }
-    @join_contacts_method_for[input_name] || input_name
+    ClientOpportunityMatchContact.join_method_for(input_name)
   end
 
   def available_contacts_method_for input_name

--- a/app/models/program_contact.rb
+++ b/app/models/program_contact.rb
@@ -8,4 +8,32 @@
 class ProgramContact < ApplicationRecord
   belongs_to :program, inverse_of: :program_contacts
   belongs_to :contact, inverse_of: :program_contacts
+
+  def self.contact_types
+    [
+      :shelter_agency,
+      :client,
+      :dnd_staff,
+      :housing_subsidy_admin,
+      :ssp,
+      :hsp,
+      :do,
+    ].freeze
+  end
+
+  def self.available_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "available_#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.available_contact_method_for(contact_type)
+    available_contact_methods[contact_type] || contact_type
+  end
+
+  def self.selected_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.selected_contact_method_for(contact_type)
+    selected_contact_methods[contact_type] || contact_type
+  end
 end

--- a/app/models/program_contacts.rb
+++ b/app/models/program_contacts.rb
@@ -84,28 +84,10 @@ class ProgramContacts
   end
 
   def available_contacts_method_for input_name
-    @available_contacts_methods ||= {
-      shelter_agency_contacts: :available_shelter_agency_contacts,
-      client_contacts: :available_client_contacts,
-      dnd_staff_contacts: :available_dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :available_housing_subsidy_admin_contacts,
-      ssp_contacts: :available_ssp_contacts,
-      hsp_contacts: :available_hsp_contacts,
-      do_contacts: :available_do_contacts,
-    }
-    @available_contacts_methods[input_name] || input_name
+    ProgramContact.available_contact_method_for(input_name)
   end
 
   def selected_contacts_method_for input_name
-    @selected_contacts_methods ||= {
-      shelter_agency_contacts: :shelter_agency_contacts,
-      client_contacts: :client_contacts,
-      dnd_staff_contacts: :dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :housing_subsidy_admin_contacts,
-      ssp_contacts: :ssp_contacts,
-      hsp_contacts: :hsp_contacts,
-      do_contacts: :do_contacts,
-    }
-    @selected_contacts_methods[input_name] || input_name
+    ProgramContact.selected_contact_method_for(input_name)
   end
 end

--- a/app/models/reporting/decisions.rb
+++ b/app/models/reporting/decisions.rb
@@ -160,6 +160,14 @@ class Reporting::Decisions < ApplicationRecord
       merge(contacts)
   end
 
+  scope :contacts_in_order, ->(contact_array, order) do
+    contacts = ClientOpportunityMatchContact.where(contact_order: order)
+    contacts.where(contact_id: contact_array) unless contact_array.blank?
+
+    joins(match: :contacts).
+      merge(contacts)
+  end
+
   scope :current_step, -> do
     where(current_step: true)
   end

--- a/app/models/reporting/decisions.rb
+++ b/app/models/reporting/decisions.rb
@@ -160,7 +160,7 @@ class Reporting::Decisions < ApplicationRecord
       merge(contacts)
   end
 
-  scope :contacts_in_order, ->(contact_array, order) do
+  scope :contacts_with_order_value, ->(contact_array, order) do
     contacts = ClientOpportunityMatchContact.where(contact_order: order)
     contacts.where(contact_id: contact_array) unless contact_array.blank?
 

--- a/app/models/reporting/filter_base.rb
+++ b/app/models/reporting/filter_base.rb
@@ -25,6 +25,7 @@ module Reporting
     attribute :cohort_ids, Array, default: []
     attribute :contacts, Array, default: []
     attribute :contact_type, Integer
+    attribute :contact_order, Integer
 
     # Defaults
     attribute :default_start, Date, default: (Date.current - 1.year).beginning_of_year
@@ -57,6 +58,7 @@ module Reporting
       self.cohort_ids = filters.dig(:cohort_ids)&.reject(&:blank?)&.map(&:to_sym).presence || cohort_ids
       self.contacts = filters.dig(:contacts)&.reject(&:blank?)&.map(&:to_sym).presence || contacts
       self.contact_type = filters.dig(:contact_type)&.presence || contact_type
+      self.contact_order = filters.dig(:contact_order)&.presence || contact_order
 
       ensure_date_order if valid?
       self
@@ -79,6 +81,7 @@ module Reporting
       scope = filter_for_cohorts(scope)
       scope = filter_for_contacts(scope)
       scope = filter_for_contact_type(scope)
+      scope = filter_for_contact_order(scope)
 
       scope
     end
@@ -102,6 +105,7 @@ module Reporting
           disabilities: disabilities,
           contacts: contacts,
           contact_type: contact_type,
+          contact_order: contact_order,
         },
       }
     end
@@ -117,6 +121,7 @@ module Reporting
         :end,
         :match_route,
         :contact_type,
+        :contact_order,
         match_routes: [],
         programs: [],
         program_types: [],

--- a/app/models/sub_program_contact.rb
+++ b/app/models/sub_program_contact.rb
@@ -7,4 +7,32 @@
 class SubProgramContact < ApplicationRecord
   belongs_to :sub_program, inverse_of: :sub_program_contacts
   belongs_to :contact, inverse_of: :sub_program_contacts
+
+  def self.contact_types
+    [
+      :shelter_agency,
+      :client,
+      :dnd_staff,
+      :housing_subsidy_admin,
+      :ssp,
+      :hsp,
+      :do,
+    ].freeze
+  end
+
+  def self.available_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "available_#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.available_contact_method_for(contact_type)
+    available_contact_methods[contact_type] || contact_type
+  end
+
+  def self.selected_contact_methods
+    contact_types.map { |t| ["#{t}_contacts".to_sym, "#{t}_contacts".to_sym] }.to_h
+  end
+
+  def self.selected_contact_method_for(contact_type)
+    selected_contact_methods[contact_type] || contact_type
+  end
 end

--- a/app/models/sub_program_contacts.rb
+++ b/app/models/sub_program_contacts.rb
@@ -85,28 +85,10 @@ class SubProgramContacts
   end
 
   def available_contacts_method_for input_name
-    @available_contacts_methods ||= {
-      shelter_agency_contacts: :available_shelter_agency_contacts,
-      client_contacts: :available_client_contacts,
-      dnd_staff_contacts: :available_dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :available_housing_subsidy_admin_contacts,
-      ssp_contacts: :available_ssp_contacts,
-      hsp_contacts: :available_hsp_contacts,
-      do_contacts: :available_do_contacts,
-    }
-    @available_contacts_methods[input_name] || input_name
+    SubProgramContact.available_contact_method_for(input_name)
   end
 
   def selected_contacts_method_for input_name
-    @selected_contacts_methods ||= {
-      shelter_agency_contacts: :shelter_agency_contacts,
-      client_contacts: :client_contacts,
-      dnd_staff_contacts: :dnd_staff_contacts,
-      housing_subsidy_admin_contacts: :housing_subsidy_admin_contacts,
-      ssp_contacts: :ssp_contacts,
-      hsp_contacts: :hsp_contacts,
-      do_contacts: :do_contacts,
-    }
-    @selected_contacts_methods[input_name] || input_name
+    SubProgramContact.selected_contact_method_for(input_name)
   end
 end

--- a/app/views/contact_manager/_contact_field.haml
+++ b/app/views/contact_manager/_contact_field.haml
@@ -13,7 +13,8 @@
 - if editable
   = form.input contact_type, collection: object.public_send(available_contacts_method), label: label, include_blank: true, input_html: {id: "#{contact_type}_#{SecureRandom.hex(5)}", class: [:select2, :jContactField], data: {contact_type: contact_type, input_name: input_name }}
   %div{ data: {selected_contacts: true} }
-    - object.send(selected_contacts_method)&.each do |contact|
+    - selected_contacts = object.send(selected_contacts_method)
+    - selected_contacts&.each do |contact|
       - join_contact = all_join_contacts[contact.id]
       .selected-contact.c-contact-list__contact.margin-0
         %input{type: :hidden, name: input_name, value: contact.id, class: :jContactHidden}
@@ -26,11 +27,12 @@
             .ml-4{data: data}
               %i.icon-warning
         .ml-auto
-          - if join_contact&.contact_order == 1
-            %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
-          - elsif join_contact.present? && current_contact&.user_can_edit_match_contacts?
-            = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post, remote: true do 
-              %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
+          - if selected_contacts.count > 1
+            - if join_contact&.contact_order == 1
+              %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
+            - elsif join_contact.present? && current_contact&.user_can_edit_match_contacts?
+              = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post, remote: true do 
+                %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
           -# Don't allow removal of self if you can't edit all contacts
           - if current_contact&.user_can_edit_match_contacts? || current_contact&.id != contact.id
             = link_to '#', data: {contact_id: contact.id, input_name: input_name}, class: 'jContactDelete c-contact-list__remove selected-contact--remove-link' do

--- a/app/views/contact_manager/_contact_field.haml
+++ b/app/views/contact_manager/_contact_field.haml
@@ -6,13 +6,15 @@
 - available_contacts_method = object.available_contacts_method_for(contact_type)
 - selected_contacts_method = object.selected_contacts_method_for(contact_type)
 - contact_ids_with_active_users = Contact.active_contacts.pluck(:id)
+- all_join_contacts = {}
+- all_join_contacts = object.public_send(object.join_contacts_method_for(contact_type)) if object.respond_to?(:join_contacts_method_for)
 
 - editable = current_user&.can_edit_match_contacts? || current_contact&.user_can_edit_match_contacts? || (hsa_can_edit_contacts? && contacts_type == 'housing_subsidy_admin')
-
 - if editable
   = form.input contact_type, collection: object.public_send(available_contacts_method), label: label, include_blank: true, input_html: {id: "#{contact_type}_#{SecureRandom.hex(5)}", class: [:select2, :jContactField], data: {contact_type: contact_type, input_name: input_name }}
   %div{ data: {selected_contacts: true} }
     - object.send(selected_contacts_method)&.each do |contact|
+      - join_contact = all_join_contacts[contact.id]
       .selected-contact.c-contact-list__contact.margin-0
         %input{type: :hidden, name: input_name, value: contact.id, class: :jContactHidden}
         - data = {}
@@ -23,10 +25,16 @@
           - unless contact_ids_with_active_users.include?(contact.id)
             .ml-4{data: data}
               %i.icon-warning
-        -# Don't allow removal of self if you can't edit all contacts
-        - if current_contact&.user_can_edit_match_contacts? || current_contact&.id != contact.id
-          = link_to '#', data: {contact_id: contact.id, input_name: input_name}, class: 'jContactDelete c-contact-list__remove selected-contact--remove-link' do
-            %i.icon-cross
+        .ml-auto
+          - if join_contact&.contact_order == 1
+            %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
+          - elsif join_contact.present? && current_contact&.user_can_edit_match_contacts?
+            = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post, remote: true do 
+              %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
+          -# Don't allow removal of self if you can't edit all contacts
+          - if current_contact&.user_can_edit_match_contacts? || current_contact&.id != contact.id
+            = link_to '#', data: {contact_id: contact.id, input_name: input_name}, class: 'jContactDelete c-contact-list__remove selected-contact--remove-link' do
+              %i.icon-cross
 - else
   .form-group
     %label.mb-4= label

--- a/app/views/contact_manager/_contact_field.haml
+++ b/app/views/contact_manager/_contact_field.haml
@@ -29,10 +29,10 @@
         .ml-auto
           - if selected_contacts.count > 1
             - if join_contact&.contact_order == 1
-              %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
+              %i.icon-checkbox-checked.ml-2.mr-4{ data: { toggle: :tooltip, title: 'Primary Contact' }}
             - elsif join_contact.present? && current_contact&.user_can_edit_match_contacts?
-              = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post, remote: true do 
-                %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
+              = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post, remote: true do
+                %i.icon-checkbox-unchecked.ml-2.mr-4{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
           -# Don't allow removal of self if you can't edit all contacts
           - if current_contact&.user_can_edit_match_contacts? || current_contact&.id != contact.id
             = link_to '#', data: {contact_id: contact.id, input_name: input_name}, class: 'jContactDelete c-contact-list__remove selected-contact--remove-link' do

--- a/app/views/match_contacts/_match_contacts_list.haml
+++ b/app/views/match_contacts/_match_contacts_list.haml
@@ -10,8 +10,7 @@
       - Translation.translate('Housing Search Providers')
       .c-detail-group__title--secondary= Translation.translate(title)
       .detail-box--value 
-        - contact_type_column = contact_type.to_s.sub('_contacts','').to_sym #TODO: This feels too hacky
-        - all_contacts = match.client_opportunity_match_contacts.where(ClientOpportunityMatchContact.arel_table[contact_type_column.to_sym].eq(true)).index_by(&:contact_id)
+        - all_contacts = match.client_opportunity_match_contacts.for_contact_type(contact_type).index_by(&:contact_id)  
         - match.send(contact_type).order(:contact_order).each do |contact|
           - join_contact = all_contacts[contact.id]
           - data = {}

--- a/app/views/match_contacts/_match_contacts_list.haml
+++ b/app/views/match_contacts/_match_contacts_list.haml
@@ -18,23 +18,17 @@
           - data = {toggle: :tooltip, title: 'No associated active user, will not receive emails.'} unless contact_ids_with_active_users.include?(contact.id)
           .contact.mb-2
             = contact.name
+            - if join_contact.contact_order == 1
+              %i.icon-user.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
             %br
-            .ml-2
-              .d-flex
-                .email= mail_to contact.email, nil, target: '_blank'
-                - unless contact_ids_with_active_users.include?(contact.id)
-                  .ml-2{data: data}
-                    %i.icon-warning
-              - phone = contact.phone_for_display
-              - if phone.present? && phone.strip.length > 1
-                = phone
-                %br
-              Primary Contact: 
-              - if join_contact.contact_order == 1
-                %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
-              - else
-                - if current_contact&.user_can_edit_match_contacts?
-                  = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post do 
-                    %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
+            .d-flex
+              .email= mail_to contact.email, nil, target: '_blank'
+              - unless contact_ids_with_active_users.include?(contact.id)
+                .ml-2{data: data}
+                  %i.icon-warning
+            - phone = contact.phone_for_display
+            - if phone.present? && phone.strip.length > 1
+              = phone
+              %br
         - if !match.send(contact_type).any?
           %p.c-detail-group__no-result No contacts

--- a/app/views/match_contacts/_match_contacts_list.haml
+++ b/app/views/match_contacts/_match_contacts_list.haml
@@ -11,13 +11,14 @@
       .c-detail-group__title--secondary= Translation.translate(title)
       .detail-box--value 
         - all_contacts = match.client_opportunity_match_contacts.for_contact_type(contact_type).index_by(&:contact_id)  
-        - match.send(contact_type).order(:contact_order).each do |contact|
+        - selected_contacts = match.send(contact_type).order(:contact_order)
+        - selected_contacts.each do |contact|
           - join_contact = all_contacts[contact.id]
           - data = {}
           - data = {toggle: :tooltip, title: 'No associated active user, will not receive emails.'} unless contact_ids_with_active_users.include?(contact.id)
           .contact.mb-2
             = contact.name
-            - if join_contact.contact_order == 1
+            - if join_contact.contact_order == 1 && selected_contacts.count > 1
               %i.icon-user.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
             %br
             .d-flex

--- a/app/views/match_contacts/_match_contacts_list.haml
+++ b/app/views/match_contacts/_match_contacts_list.haml
@@ -9,21 +9,32 @@
       - Translation.translate('Stabilization Service Providers')
       - Translation.translate('Housing Search Providers')
       .c-detail-group__title--secondary= Translation.translate(title)
-      .detail-box--value
-        - match.send(contact_type).each do |contact|
+      .detail-box--value 
+        - contact_type_column = contact_type.to_s.sub('_contacts','').to_sym #TODO: This feels too hacky
+        - all_contacts = match.client_opportunity_match_contacts.where(ClientOpportunityMatchContact.arel_table[contact_type_column.to_sym].eq(true)).index_by(&:contact_id)
+        - match.send(contact_type).order(:contact_order).each do |contact|
+          - join_contact = all_contacts[contact.id]
           - data = {}
           - data = {toggle: :tooltip, title: 'No associated active user, will not receive emails.'} unless contact_ids_with_active_users.include?(contact.id)
           .contact.mb-2
             = contact.name
             %br
-            .d-flex
-              .email= mail_to contact.email, nil, target: '_blank'
-              - unless contact_ids_with_active_users.include?(contact.id)
-                .ml-2{data: data}
-                  %i.icon-warning
-            - phone = contact.phone_for_display
-            - if phone.present? && phone.strip.length > 1
-              %br
-              = phone
+            .ml-2
+              .d-flex
+                .email= mail_to contact.email, nil, target: '_blank'
+                - unless contact_ids_with_active_users.include?(contact.id)
+                  .ml-2{data: data}
+                    %i.icon-warning
+              - phone = contact.phone_for_display
+              - if phone.present? && phone.strip.length > 1
+                = phone
+                %br
+              Primary Contact: 
+              - if join_contact.contact_order == 1
+                %i.icon-checkbox-checked.ml-2{ data: { toggle: :tooltip, title: 'Primary Contact' }}
+              - else
+                - if current_contact&.user_can_edit_match_contacts?
+                  = link_to reorder_match_contacts_path(@match, join_contact: join_contact), method: :post do 
+                    %i.icon-checkbox-unchecked.ml-2{ data: { toggle: :tooltip, title: 'Set Primary Contact' }}
         - if !match.send(contact_type).any?
           %p.c-detail-group__no-result No contacts

--- a/app/views/match_contacts/reorder.js.erb
+++ b/app/views/match_contacts/reorder.js.erb
@@ -1,0 +1,20 @@
+(function() {
+  <% if @match_contacts.errors.any? %>
+    $('form.jContactForm .alert.alert-danger .jContactFormErrors').remove();
+    $('form.jContactForm').prepend('<div class="alert alert-danger jContactFormErrors"><%= @match_contacts.errors.full_messages.join(', ') %></div>');
+  <% else %>
+    let contact_form_html = "<%= j render 'form' %>";
+    $('.jContactForm').replaceWith(contact_form_html);
+
+    $('.jDnDStaffContactForm').each(function(i) {
+      let dnd_contact_form_html = "<%= j render 'matches/match_contacts_form' %>"
+      $(this).replaceWith('dnd_contact_form_html',dnd_contact_form_html)
+    });
+
+    let match_contact_form_html = "<%= j render 'match_contacts/match_contacts_list', match: @match_contacts.match %>";
+    $('.jMatchContactList').replaceWith(match_contact_form_html);
+    $('select.select2').each(function(i) {
+      $(this).select2({dropdownParent: $(this).closest('form')});
+    });
+  <% end %>
+})()

--- a/app/views/match_contacts/reorder.js.erb
+++ b/app/views/match_contacts/reorder.js.erb
@@ -16,5 +16,6 @@
     $('select.select2').each(function(i) {
       $(this).select2({dropdownParent: $(this).closest('form')});
     });
+    $('[data-toggle="tooltip"]').tooltip();
   <% end %>
 })()

--- a/app/views/match_contacts/update.js.erb
+++ b/app/views/match_contacts/update.js.erb
@@ -16,5 +16,6 @@
     $('select.select2').each(function(i) {
       $(this).select2({dropdownParent: $(this).closest('form')});
     });
+    $('[data-toggle="tooltip"]').tooltip();
   <% end %>
 })()

--- a/app/views/reports/dashboards/contacts/_contacts_filter.haml
+++ b/app/views/reports/dashboards/contacts/_contacts_filter.haml
@@ -9,4 +9,7 @@
       = f.input :contacts, as: :select_2, collection: @filter.contact_options_for_select, input_html: { multiple: true }
     .col-3
       = f.input :contact_type, as: :select_2, collection: @filter.contact_type_options_for_select, include_blank: 'Any Contact Type'
+  .row
+    .col-3
+      = f.input :contact_order, as: :boolean, label: 'Only primary contacts'
   = f.submit 'Update Dashboard', class: 'btn btn-primary'

--- a/app/views/sub_programs/_form.html.haml
+++ b/app/views/sub_programs/_form.html.haml
@@ -14,7 +14,7 @@
               = f.input :confidential, label: 'Is this a confidential sub-program?', hint: 'Anyone in a match involving a confidential program will have their name hidden on lists of matches by default.'
             = f.input :cori_hearing_required, label: "Requires #{Translation.translate('CORI hearing')}", hint: "This sub-program requires a #{Translation.translate('CORI hearing')} review for any clients matched in #{Translation.translate('Route Thirteen')}"
             - scheme = @subprogram.match_route.match_prioritization.title
-            = f.association :match_prioritization, collection: MatchPrioritization::Base.prioritization_schemes.map {|prioritization_scheme| [prioritization_scheme.title, prioritization_scheme.first.id]}, label_method: :first, value_method: :second, include_blank: "Use Prioritization from Route: #{scheme}", as: :select_2
+            = f.association :match_prioritization, collection: MatchPrioritization::Base.prioritization_schemes.map {|prioritization_scheme| [prioritization_scheme.title, prioritization_scheme.first&.id]}, label_method: :first, value_method: :second, include_blank: "Use Prioritization from Route: #{scheme}", as: :select_2
             = f.association :housing_subsidy_administrator, label: "#{Translation.translate('Housing Subsidy Administrator')}", as: :select2
             = f.association :service_provider, label: 'Service Provider', as: :select2
             = f.association :sub_contractor, label: 'Sub-Contractor', as: :select2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,9 @@ Rails.application.routes.draw do
         get :recreate_hsa_notifications_nine, on: :member
       end
 
-      resource :contacts, only: [:edit, :update], controller: 'match_contacts'
+      resource :contacts, only: [:edit, :update], controller: 'match_contacts' do
+        post 'reorder', on: :collection
+      end
       resources :notes, only: [:new, :create, :edit, :update, :destroy], controller: 'match_notes'
       resource :client_details, only: [:show], controller: 'match_client_details'
       resources :match_progress_updates, only: [:create], shallow: true

--- a/db/migrate/20240827172144_add_contact_order_to_contacts.rb
+++ b/db/migrate/20240827172144_add_contact_order_to_contacts.rb
@@ -1,0 +1,12 @@
+class AddContactOrderToContacts < ActiveRecord::Migration[7.0]
+  def change
+    [
+      :building_contacts,
+      :client_opportunity_match_contacts,
+      :opportunity_contacts,
+      :subgrantee_contacts
+    ].each do |table|
+      add_column table, :contact_order, :integer
+    end
+  end
+end

--- a/db/migrate/20240827172144_add_contact_order_to_contacts.rb
+++ b/db/migrate/20240827172144_add_contact_order_to_contacts.rb
@@ -1,5 +1,20 @@
 class AddContactOrderToContacts < ActiveRecord::Migration[7.0]
   def change
     add_column :client_opportunity_match_contacts, :contact_order, :integer
+    
+    # Set contact_order to 1 for all single contact types on a match
+    [
+      :dnd_staff,
+      :housing_subsidy_admin,
+      :client,
+      :housing_search_worker,
+      :shelter_agency,
+      :ssp,
+      :hsp,
+      :do,
+    ].each do |type|
+      match_ids = ClientOpportunityMatchContact.select(:match_id).where(type => true).group(:match_id).having('count(*) = 1').pluck(:match_id)
+      ClientOpportunityMatchContact.where(match_id: match_ids, type => type).update_all(contact_order: 1)
+    end
   end
 end

--- a/db/migrate/20240827172144_add_contact_order_to_contacts.rb
+++ b/db/migrate/20240827172144_add_contact_order_to_contacts.rb
@@ -4,7 +4,7 @@ class AddContactOrderToContacts < ActiveRecord::Migration[7.0]
       :building_contacts,
       :client_opportunity_match_contacts,
       :opportunity_contacts,
-      :subgrantee_contacts
+      :subgrantee_contacts,
     ].each do |table|
       add_column table, :contact_order, :integer
     end

--- a/db/migrate/20240827172144_add_contact_order_to_contacts.rb
+++ b/db/migrate/20240827172144_add_contact_order_to_contacts.rb
@@ -1,12 +1,5 @@
 class AddContactOrderToContacts < ActiveRecord::Migration[7.0]
   def change
-    [
-      :building_contacts,
-      :client_opportunity_match_contacts,
-      :opportunity_contacts,
-      :subgrantee_contacts,
-    ].each do |table|
-      add_column table, :contact_order, :integer
-    end
+    add_column :client_opportunity_match_contacts, :contact_order, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_27_172144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
+    t.integer "contact_order"
     t.index ["building_id"], name: "index_building_contacts_on_building_id"
     t.index ["contact_id"], name: "index_building_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_building_contacts_on_deleted_at"
@@ -127,6 +128,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.boolean "ssp", default: false, null: false
     t.boolean "hsp", default: false, null: false
     t.boolean "do", default: false, null: false
+    t.integer "contact_order"
     t.index ["contact_id"], name: "index_client_opportunity_match_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_client_opportunity_match_contacts_on_deleted_at"
     t.index ["match_id"], name: "index_client_opportunity_match_contacts_on_match_id"
@@ -332,7 +334,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.jsonb "ongoing_es_enrollments"
     t.jsonb "ongoing_so_enrollments"
     t.jsonb "last_seen_projects"
-    t.boolean "federal_benefits"
     t.index ["active_cohort_ids"], name: "index_clients_on_active_cohort_ids"
     t.index ["available"], name: "index_clients_on_available"
     t.index ["calculated_last_homeless_night"], name: "index_clients_on_calculated_last_homeless_night"
@@ -1004,7 +1005,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.text "partner_warehouse_id"
     t.text "partner_name"
     t.boolean "share_information_permission"
-    t.boolean "federal_benefits"
     t.index ["agency_id"], name: "index_non_hmis_assessments_on_agency_id"
     t.index ["user_id"], name: "index_non_hmis_assessments_on_user_id"
   end
@@ -1101,7 +1101,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.boolean "no_single_gender", default: false
     t.boolean "transgender", default: false
     t.boolean "questioning", default: false
-    t.boolean "federal_benefits"
     t.index ["deleted_at"], name: "index_non_hmis_clients_on_deleted_at"
   end
 
@@ -1139,6 +1138,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
     t.boolean "housing_subsidy_admin", default: false, null: false
+    t.integer "contact_order"
     t.index ["contact_id"], name: "index_opportunity_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_opportunity_contacts_on_deleted_at"
     t.index ["opportunity_id"], name: "index_opportunity_contacts_on_opportunity_id"
@@ -1386,7 +1386,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.jsonb "ongoing_es_enrollments"
     t.jsonb "ongoing_so_enrollments"
     t.jsonb "last_seen_projects"
-    t.boolean "federal_benefits"
     t.index ["calculated_chronic_homelessness"], name: "index_project_clients_on_calculated_chronic_homelessness"
     t.index ["client_id"], name: "index_project_clients_on_client_id"
     t.index ["date_of_birth"], name: "index_project_clients_on_date_of_birth"
@@ -1694,6 +1693,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_22_155547) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
+    t.integer "contact_order"
     t.index ["contact_id"], name: "index_subgrantee_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_subgrantee_contacts_on_deleted_at"
     t.index ["subgrantee_id"], name: "index_subgrantee_contacts_on_subgrantee_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_27_172144) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
-    t.integer "contact_order"
     t.index ["building_id"], name: "index_building_contacts_on_building_id"
     t.index ["contact_id"], name: "index_building_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_building_contacts_on_deleted_at"
@@ -1138,7 +1137,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_27_172144) do
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
     t.boolean "housing_subsidy_admin", default: false, null: false
-    t.integer "contact_order"
     t.index ["contact_id"], name: "index_opportunity_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_opportunity_contacts_on_deleted_at"
     t.index ["opportunity_id"], name: "index_opportunity_contacts_on_opportunity_id"
@@ -1693,7 +1691,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_27_172144) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "deleted_at", precision: nil
-    t.integer "contact_order"
     t.index ["contact_id"], name: "index_subgrantee_contacts_on_contact_id"
     t.index ["deleted_at"], name: "index_subgrantee_contacts_on_deleted_at"
     t.index ["subgrantee_id"], name: "index_subgrantee_contacts_on_subgrantee_id"


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Adds the option to set a primary contact for each contact type in a match. This works in the modal and non-modal version of the edit match contacts and displays the primary contact in the contacts partial displayed on the match page.

The first match added as a contact for each type is automatically designated as the primary contact.

A button to filter just primary contacts is also included in the Matches by Contacts dashboard report.

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
