### PR TITLE
Clear voucher date available if the voucher is being made unavailable

### DIFF
--- a/app/controllers/match_decisions_controller.rb
+++ b/app/controllers/match_decisions_controller.rb
@@ -128,7 +128,7 @@ class MatchDecisionsController < ApplicationController
 
           if decision_params[:disable_opportunity] == '1'
             voucher = @match.opportunity.voucher
-            voucher.update(available: false) if voucher.present?
+            voucher.update(available: false, date_available: nil) if voucher.present?
             @match.opportunity.update(available: false, available_candidate: false)
           end
 


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

When a match is canceled and the opportunity is marked as should not re-match, if the voucher still has an available after date, the engine will re-match it anyway.  This clears that date if the voucher should not re-match.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
