### PR TITLE
CE Events from CAS Matches

### DIFF
--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -463,9 +463,9 @@ class ClientOpportunityMatch < ApplicationRecord
   end
 
   def unsuccessful_reason
-    return unsuccessful_decision.administrative_cancel_reason if canceled?
+    return unsuccessful_decision&.administrative_cancel_reason if canceled?
 
-    unsuccessful_decision.decline_reason
+    unsuccessful_decision&.decline_reason
   end
 
   # Find the latest decision in the route that was declined with a reason

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -457,14 +457,35 @@ class ClientOpportunityMatch < ApplicationRecord
   end
 
   def unsuccessful_decision
-    initialized_decisions.where.not(decline_reason_id: nil)&.first ||
-      initialized_decisions.where.not(administrative_cancel_reason_id: nil)&.first
+    return canceled_decision if canceled?
+
+    declined_decision
   end
 
+  def unsuccessful_reason
+    return unsuccessful_decision.administrative_cancel_reason if canceled?
+
+    unsuccessful_decision.decline_reason
+  end
+
+  # Find the latest decision in the route that was declined with a reason
+  # If that doesn't exist, pull the latest initialized decision that was declined
   def declined_decision
-    @declined_decision ||= initialized_decisions.where.not(decline_reason_id: nil)&.first
-    @declined_decision ||= initialized_decisions.where(status: :declined)&.last
+    decision_order = match_route.class.match_steps_for_reporting.keys
+    @declined_decision ||= initialized_decisions.order_as_specified(type: decision_order).where.not(decline_reason_id: nil)&.last
+    @declined_decision ||= initialized_decisions.order_as_specified(type: decision_order).where(status: :declined)&.last
     @declined_decision
+  end
+
+  # Find the latest decision in the route that was canceled with a reason
+  # If that doesn't exist, pull the latest initialized decision that was canceled
+  def canceled_decision
+    return nil unless canceled?
+
+    decision_order = match_route.class.match_steps_for_reporting.keys
+    @canceled_decision ||= initialized_decisions.order_as_specified(type: decision_order).where.not(administrative_cancel_reason_id: nil)&.last
+    @canceled_decision ||= initialized_decisions.order_as_specified(type: decision_order).where(status: :canceled)&.last
+    @canceled_decision
   end
 
   def clear_current_decision_cache!

--- a/app/models/warehouse/referral_event.rb
+++ b/app/models/warehouse/referral_event.rb
@@ -20,7 +20,7 @@ module Warehouse
     end
 
     def rejected
-      reason = client_opportunity_match.current_decision&.decline_reason
+      reason = client_opportunity_match.unsuccessful_reason
       if reason&.referral_result.present?
         update(referral_result: reason.referral_result, referral_result_date: reason.referral_result_date)
       else
@@ -62,7 +62,7 @@ module Warehouse
             )
           end
         else
-          reason = match.current_decision&.decline_reason
+          reason = match.unsuccessful_reason
           if reason.present? && reason.referral_result.present?
             if event.referral_result != reason.referral_result
               event.update(

--- a/app/models/warehouse/referral_event.rb
+++ b/app/models/warehouse/referral_event.rb
@@ -63,12 +63,14 @@ module Warehouse
           end
         else
           reason = match.unsuccessful_reason
+          unsuccessful_decision = match.unsuccessful_decision
+          closed_timestamp = unsuccessful_decision&.updated_at || match.updated_at
           if reason.present? && reason.referral_result.present?
             if event.referral_result != reason.referral_result
               event.update(
                 event: match.sub_program.event,
                 referral_result: reason.referral_result,
-                referral_result_date: reason.referral_result_date,
+                referral_result_date: closed_timestamp,
               )
             end
           else

--- a/app/models/warehouse/referral_event.rb
+++ b/app/models/warehouse/referral_event.rb
@@ -21,8 +21,10 @@ module Warehouse
 
     def rejected
       reason = client_opportunity_match.unsuccessful_reason
+      unsuccessful_decision = client_opportunity_match.unsuccessful_decision
+      closed_timestamp = unsuccessful_decision&.updated_at || client_opportunity_match.updated_at
       if reason&.referral_result.present?
-        update(referral_result: reason.referral_result, referral_result_date: reason.referral_result_date)
+        update(referral_result: reason.referral_result, referral_result_date: closed_timestamp)
       else
         destroy
       end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
WIP

This corrects some assumptions for canceled and declined matches and how they generate referral events.  Specifically, canceled matches were not identifying the reason for CE reporting correctly, and matches that didn't end with a decline, but which were declined, couldn't always find their reasons.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
