### PR TITLE
Add CoC Confirmation Decision to Route 11

### DIFF
--- a/app/models/concerns/route_eleven_decisions.rb
+++ b/app/models/concerns/route_eleven_decisions.rb
@@ -11,5 +11,6 @@ module RouteElevenDecisions
     has_decision :eleven_hsa_acknowledges_receipt, decision_class_name: 'MatchDecisions::Eleven::ElevenHsaAcknowledgesReceipt', notification_class_name: 'Notifications::Eleven::MatchInitiationForHsa'
     has_decision :eleven_hsa_accepts_client, decision_class_name: 'MatchDecisions::Eleven::ElevenHsaAcceptsClient', notification_class_name: 'Notifications::Eleven::HsaAcceptsClient'
     has_decision :eleven_confirm_hsa_accepts_client_decline_dnd_staff, decision_class_name: 'MatchDecisions::Eleven::ElevenConfirmHsaAcceptsClientDeclineDndStaff', notification_class_name: 'Notifications::ConfirmHousingSubsidyAdminDeclineDndStaff'
+    has_decision :eleven_confirm_match_success_dnd_staff, decision_class_name: 'MatchDecisions::Eleven::ElevenConfirmMatchSuccessDndStaff', notification_class_name: 'Notifications::Eleven::ConfirmMatchSuccessDndStaff'
   end
 end

--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -86,7 +86,7 @@ module MatchDecisions
     def editable?
       # can this decision be updated by a notification response?
       # override this default behavior in subclasses
-      initialized? && match_open? && saved_status !~ /\A(accepted|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
+      initialized? && match_open? && saved_status !~ /\A(accepted|acknowledged|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
     end
 
     def expires?

--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -86,7 +86,7 @@ module MatchDecisions
     def editable?
       # can this decision be updated by a notification response?
       # override this default behavior in subclasses
-      initialized? && match_open? && saved_status !~ /\A(accepted|acknowledged|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
+      initialized? && match_open? && saved_status !~ /\A(accepted|confirmed|declined|canceled|rejected|complete|completed|scheduled|no_hearing|mitigation_required|mitigation_not_required|decline_overridden|decline_overridden_returned|decline_confirmed)\z/
     end
 
     def expires?

--- a/app/models/match_decisions/eleven/eleven_confirm_match_success_dnd_staff.rb
+++ b/app/models/match_decisions/eleven/eleven_confirm_match_success_dnd_staff.rb
@@ -9,7 +9,6 @@ module MatchDecisions::Eleven
     include MatchDecisions::AcceptsDeclineReason
     include MatchDecisions::RouteElevenDeclineReasons
     include MatchDecisions::RouteElevenCancelReasons
-    # validate :note_present_if_status_rejected
 
     def to_partial_path
       'match_decisions/eleven/confirm_match_success_dnd_staff'
@@ -19,7 +18,6 @@ module MatchDecisions::Eleven
       {
         pending: 'Pending',
         confirmed: 'Confirmed',
-        rejected: 'Rejected', # Not currently used
         declined: 'Declined',
         canceled: 'Canceled',
         back: 'Pending',

--- a/app/models/match_decisions/eleven/eleven_confirm_match_success_dnd_staff.rb
+++ b/app/models/match_decisions/eleven/eleven_confirm_match_success_dnd_staff.rb
@@ -1,0 +1,109 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+module MatchDecisions::Eleven
+  class ElevenConfirmMatchSuccessDndStaff < ::MatchDecisions::Base
+    include MatchDecisions::AcceptsDeclineReason
+    include MatchDecisions::RouteElevenDeclineReasons
+    include MatchDecisions::RouteElevenCancelReasons
+    # validate :note_present_if_status_rejected
+
+    def to_partial_path
+      'match_decisions/eleven/confirm_match_success_dnd_staff'
+    end
+
+    def statuses
+      {
+        pending: 'Pending',
+        confirmed: 'Confirmed',
+        rejected: 'Rejected', # Not currently used
+        declined: 'Declined',
+        canceled: 'Canceled',
+        back: 'Pending',
+      }
+    end
+
+    def label
+      label_for_status status
+    end
+
+    def label_for_status status
+      case status.to_sym
+      when :pending then "#{Translation.translate('CoC Eleven')} to confirm match success"
+      when :confirmed then "#{Translation.translate('CoC Eleven')} confirms match success"
+      when :rejected, :declined then "Match rejected by #{Translation.translate('CoC Eleven')}.  Reason: #{decline_reason_name}"
+      when :canceled then canceled_status_label
+      when :back then backup_status_label
+      end
+    end
+
+    def started?
+      status&.to_sym == :confirmed
+    end
+
+    def step_name
+      "#{Translation.translate('CoC Eleven')} Review Match Success"
+    end
+
+    def actor_type
+      Translation.translate('CoC Eleven')
+    end
+
+    def contact_actor_type
+      :dnd_staff_contacts
+    end
+
+    def initialize_decision! send_notifications: true
+      super(send_notifications: send_notifications)
+      update status: 'pending'
+      send_notifications_for_step if send_notifications
+    end
+
+    def notifications_for_this_step
+      @notifications_for_this_step ||= [].tap do |m|
+        m << Notifications::Eleven::ConfirmMatchSuccessDndStaff
+      end
+    end
+
+    def accessible_by? contact
+      contact&.user_can_reject_matches? || contact&.user_can_approve_matches?
+    end
+
+    def to_param
+      :eleven_confirm_match_success_dnd_staff
+    end
+
+    private def note_present_if_status_rejected
+      errors.add :note, 'Please note why the match is declined.' if note.blank? && status == 'rejected'
+    end
+
+    class StatusCallbacks < StatusCallbacks
+      def pending
+      end
+
+      def confirmed
+        Notifications::MatchSuccessConfirmed.create_for_match! match
+        match.succeeded!(user: user)
+      end
+
+      def declined
+        Notifications::MatchDeclined.create_for_match! match
+        match.rejected!
+      end
+
+      def canceled
+        Notifications::MatchCanceled.create_for_match! match
+        match.canceled!
+      end
+
+      def rejected
+        Notifications::MatchRejected.create_for_match! match
+        match.rejected!
+      end
+    end
+    private_constant :StatusCallbacks
+  end
+end

--- a/app/models/match_decisions/eleven/eleven_hsa_accepts_client.rb
+++ b/app/models/match_decisions/eleven/eleven_hsa_accepts_client.rb
@@ -101,7 +101,7 @@ module MatchDecisions::Eleven
 
       def accepted
         Notifications::Eleven::HsaAcceptsClientSspNotification.create_for_match! match
-        match.succeeded!(user: user)
+        @decision.next_step.initialize_decision!
       end
 
       def declined

--- a/app/models/match_routes/eleven.rb
+++ b/app/models/match_routes/eleven.rb
@@ -18,6 +18,7 @@ module MatchRoutes
       {
         'MatchDecisions::Eleven::ElevenHsaAcknowledgesReceipt' => 1,
         'MatchDecisions::Eleven::ElevenHsaAcceptsClient' => 2,
+        'MatchDecisions::Eleven::ElevenConfirmMatchSuccessDndStaff' => 3,
       }
     end
 
@@ -26,6 +27,7 @@ module MatchRoutes
         'MatchDecisions::Eleven::ElevenHsaAcknowledgesReceipt' => 1,
         'MatchDecisions::Eleven::ElevenHsaAcceptsClient' => 2,
         'MatchDecisions::Eleven::ElevenConfirmHsaAcceptsClientDeclineDndStaff' => 3,
+        'MatchDecisions::Eleven::ElevenConfirmMatchSuccessDndStaff' => 4,
       }
     end
 
@@ -41,7 +43,7 @@ module MatchRoutes
     end
 
     def success_decision
-      :eleven_hsa_accepts_client_decision
+      :eleven_confirm_match_success_dnd_staff_decision
     end
 
     def initial_contacts_for_match

--- a/app/models/notifications/eleven/confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/eleven/confirm_match_success_dnd_staff.rb
@@ -1,0 +1,23 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+module Notifications::Eleven
+  class ConfirmMatchSuccessDndStaff < ::Notifications::Base
+    def self.create_for_match! match
+      match.dnd_staff_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.eleven_confirm_match_success_dnd_staff_decision
+    end
+
+    def event_label
+      "#{Translation.translate('CoC Eleven')} Staff notified of successful match and asked to give final confirmation."
+    end
+  end
+end

--- a/app/views/match_decisions/eleven/_confirm_match_success_dnd_staff.haml
+++ b/app/views/match_decisions/eleven/_confirm_match_success_dnd_staff.haml
@@ -1,0 +1,18 @@
+.match-decision.c-card.c-card--flush.card--block
+  .c-card__content
+    = simple_form_for @decision, url: access_context.match_decision_path(@match, @decision) do |form|
+      .o-pre-choose
+        .form-inputs
+          .row
+            .col-md-6
+              = form.input :note, as: :text, input_html: {rows: 4, disabled: !(@decision.editable?)}
+      .o-choose.o-choose--flush
+        .o-choose__choice{class: ('o-choose__choice--disabled' if !@decision.editable?)}
+          %header
+            .o-choose__title
+              .c-choice-icon.c-choice-icon--confirm.mr-4
+              %h3 Confirm Match
+          .o-choose__content
+            %p Confirming match success will complete the match and remove the client and voucher/unit from future matching.
+            = render 'match_decisions/continue_button', text: 'Confirm Match Success', icon: 'checkmark', button_attributes: { class: 'btn btn-success', data: {submit_param_name: 'decision[status]', submit_param_value: 'confirmed'}, disabled: !(@decision.editable?) }
+        = render 'match_decisions/decline_and_cancel_backup_actions', form: form

--- a/app/views/matches/_current_step_info.haml
+++ b/app/views/matches/_current_step_info.haml
@@ -1,21 +1,21 @@
 .d-flex.mb-5.align-items-end.flex-wrap
-  - if @match.current_decision.present?
-    .d-flex.flex-column
-      .summary-readout.mb-3
-        .summary-readout--tile
-          %h3.h4 Current Step
-          %h1.h2
-            -if !@match.overall_status[:name] == "In Progress"
-              = match.overall_status[:name]
-            -else
-              = @match.current_decision.step_name
-        .summary-readout--tile
-          %h3.h4 Assigned To
-          %h1.h2
-            = @match.current_decision.try(:actor_type) || 'N/A'
-      = render 'match_list_base/current_step', match: @match
-  - else
+  - unless @match.current_decision.present?
     = render 'matches/restrictions_on_reopening'
+.d-flex.mb-5.align-items-end.flex-wrap
+  .d-flex.flex-column
+    .summary-readout.mb-3
+      .summary-readout--tile
+        %h3.h4 Current Step
+        %h1.h2
+          -if @match.overall_status[:name] != "In Progress"
+            = @match.overall_status[:name]
+          -else
+            = @match.current_decision.step_name
+      .summary-readout--tile
+        %h3.h4 Assigned To
+        %h1.h2
+          = @match.current_decision&.try(:actor_type) || 'N/A'
+    = render 'match_list_base/current_step', match: @match
   %div.ml-auto
     - if @match.can_create_overall_note?(access_context.current_contact)
       .btn-label.btn-label__primary

--- a/app/views/matches/_current_step_info.haml
+++ b/app/views/matches/_current_step_info.haml
@@ -1,5 +1,5 @@
 .d-flex.mb-5.align-items-end.flex-wrap
-  - unless @match.current_decision.present?
+  - if @match.current_decision.blank?
     = render 'matches/restrictions_on_reopening'
 .d-flex.mb-5.align-items-end.flex-wrap
   .d-flex.flex-column

--- a/app/views/notifications_mailer/eleven_confirm_match_success_dnd_staff.text.haml
+++ b/app/views/notifications_mailer/eleven_confirm_match_success_dnd_staff.text.haml
@@ -1,0 +1,17 @@
+Hello #{@contact.full_name},
+\
+= "The match now requires final approval from #{Translation.translate('CoC Eleven')} staff to complete."
+\
+Please review the details of the match and note final approval here:
+#{notification_match_decision_url @notification, @match, @decision}
+\
+= render 'client_details'
+\
+= render 'location_details'
+\
+= render 'program_details'
+\
+\
+\
+\
+= render 'email_footer'

--- a/db/migrate/20241010194153_destroy_route_eleven_matches.rb
+++ b/db/migrate/20241010194153_destroy_route_eleven_matches.rb
@@ -1,5 +1,5 @@
 class DestroyRouteElevenMatches < ActiveRecord::Migration[7.0]
   def change
-    ClientOpportunityMatch.joins(:match_route).where(match_routes: {type: 'MatchRoutes::Eleven'}).destroy_all unless Rails.env.production?
+    ClientOpportunityMatch.joins(:match_route).where(match_routes: { type: 'MatchRoutes::Eleven' }).destroy_all unless Rails.env.production?
   end
 end

--- a/db/migrate/20241010194153_destroy_route_eleven_matches.rb
+++ b/db/migrate/20241010194153_destroy_route_eleven_matches.rb
@@ -1,0 +1,8 @@
+class DestroyRouteElevenMatches < ActiveRecord::Migration[7.0]
+  def change
+    unless Rails.env.production? 
+      matches = ClientOpportunityMatch.where(match_route: MatchRoutes::Eleven.ids)
+      ClientOpportunityMatch.destroy(matches.ids)
+    end
+  end
+end

--- a/db/migrate/20241010194153_destroy_route_eleven_matches.rb
+++ b/db/migrate/20241010194153_destroy_route_eleven_matches.rb
@@ -1,8 +1,5 @@
 class DestroyRouteElevenMatches < ActiveRecord::Migration[7.0]
   def change
-    unless Rails.env.production? 
-      matches = ClientOpportunityMatch.where(match_route: MatchRoutes::Eleven.ids)
-      ClientOpportunityMatch.destroy(matches.ids)
-    end
+    ClientOpportunityMatch.joins(:match_route).where(match_routes: {type: 'MatchRoutes::Eleven'}).destroy_all unless Rails.env.production?
   end
 end

--- a/db/migrate/20241010194153_destroy_route_eleven_matches.rb
+++ b/db/migrate/20241010194153_destroy_route_eleven_matches.rb
@@ -1,5 +1,5 @@
 class DestroyRouteElevenMatches < ActiveRecord::Migration[7.0]
-  def change
+  def up
     ClientOpportunityMatch.joins(:match_route).where(match_routes: { type: 'MatchRoutes::Eleven' }).destroy_all unless Rails.env.production?
   end
 end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description
Add a new decision to the end of route 11 that allows the CoC to confirm the success of the match.

Also included is a script that will clear out any route 11 matches (unless on production)

## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [X] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [X] My code follows the style guidelines of this project (rubocop)
- [X] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
