### PR TITLE
Add new tab for archived vouchers within a program's vouchers/units

### DIFF
--- a/app/controllers/archived_vouchers_controller.rb
+++ b/app/controllers/archived_vouchers_controller.rb
@@ -1,0 +1,20 @@
+###
+# Copyright 2016 - 2024 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+class ArchivedVouchersController < VouchersController
+  def index
+    @show_search = true
+    @vouchers = @subprogram.vouchers.order(:id)
+    @vouchers_for_page = @vouchers.archived
+    @voucher_state = 'archived'
+  end
+
+  def restore
+    @voucher.update(archived_at: nil)
+    flash[:notice] = 'Voucher restored'
+    redirect_to action: :index
+  end
+end

--- a/app/controllers/archived_vouchers_controller.rb
+++ b/app/controllers/archived_vouchers_controller.rb
@@ -13,7 +13,7 @@ class ArchivedVouchersController < VouchersController
   end
 
   def restore
-    @voucher.update(archived_at: nil)
+    @voucher.update(archived_at: nil, available: false, date_available: nil)
     flash[:notice] = 'Voucher restored'
     redirect_to action: :index
   end

--- a/app/controllers/vouchers_controller.rb
+++ b/app/controllers/vouchers_controller.rb
@@ -7,12 +7,12 @@
 class VouchersController < ApplicationController
   before_action :authenticate_user!
   before_action :require_can_view_vouchers!
-  before_action :require_can_edit_vouchers!, only: [:edit, :update, :destroy, :create, :bulk_update]
+  before_action :require_can_edit_vouchers!, only: [:edit, :update, :destroy, :create, :bulk_update, :restore]
   before_action :require_can_reject_matches!, only: [:unavailable]
   before_action :require_can_edit_voucher_rules!, only: [:edit, :update]
-  before_action :set_voucher, only: [:edit, :update, :destroy, :unavailable, :archive]
-  before_action :set_sub_program, only: [:edit, :update, :create, :index, :bulk_update, :unavailable, :archive]
-  before_action :set_program, only: [:edit, :update, :index, :bulk_update, :unavailable, :archive]
+  before_action :set_voucher, only: [:edit, :update, :destroy, :unavailable, :archive, :restore]
+  before_action :set_sub_program, only: [:edit, :update, :create, :index, :bulk_update, :unavailable, :archive, :restore]
+  before_action :set_program, only: [:edit, :update, :index, :bulk_update, :unavailable, :archive, :restore]
   before_action :set_show_confidential_names
   include AjaxModalRails::Controller
   include Search

--- a/app/models/voucher.rb
+++ b/app/models/voucher.rb
@@ -145,7 +145,11 @@ class Voucher < ApplicationRecord
   end
 
   def can_be_archived?
-    ! available && ! active_matches?
+    ! available && ! active_matches? && ! archived?
+  end
+
+  def archived?
+    archived_at.present?
   end
 
   def active_matches?

--- a/app/views/vouchers/_tabs.haml
+++ b/app/views/vouchers/_tabs.haml
@@ -5,6 +5,8 @@
     = link_to 'In Progress', program_sub_program_in_progress_vouchers_path, class: 'nav-link'
   %li.nav-item{role: :presentation, class: ('active' if current_page?(program_sub_program_successful_vouchers_path))}
     = link_to 'Successful', program_sub_program_successful_vouchers_path, class: 'nav-link'
+  %li.nav-item{role: :presentation, class: ('active' if current_page?(program_sub_program_archived_vouchers_path))}
+    = link_to 'Archived', program_sub_program_archived_vouchers_path, class: 'nav-link'
 
 = render "form", vouchers: @vouchers_for_page
 

--- a/app/views/vouchers/_voucher.haml
+++ b/app/views/vouchers/_voucher.haml
@@ -4,7 +4,7 @@
 - default_building_id = voucher.building.try(:id)
 - default_unit_id = voucher.unit.try(:id)
 - default_unit_name = voucher.unit.try(:name)
-- if voucher.status_match.present? || @subprogram.closed?
+- if voucher.status_match.present? || @subprogram.closed? || voucher.archived?
   - disabled = true
 - else
   - disabled_units = voucher&.building&.unavailable_units_for_vouchers_ids
@@ -94,6 +94,10 @@
               %h3.detail-box--label.mt-4 History
               = link_to closed_opportunity_matches_path(voucher.opportunity) do
                 Closed Matches
+        - if voucher.archived?
+          %h3.detail-box--label.mt-4 Archived
+          .detail-box-value
+            = voucher.archived_at
 
     .detail-box-value.d-flex.flex-wrap.justify-content-end.align-items-end
       - if voucher.can_be_destroyed?
@@ -101,6 +105,10 @@
           %span.icon-cross
           Delete
       - elsif voucher.can_be_archived?
-        = link_to archive_program_sub_program_voucher_path(id: voucher.id), method: :patch, data: {confirm: "Are you sure you want to archive this voucher? Archiving will hide this voucher permanently."}, class: 'btn btn-warning btn-sm' do
+        = link_to archive_program_sub_program_voucher_path(id: voucher.id), method: :patch, data: {confirm: "Are you sure you want to archive this voucher?"}, class: 'btn btn-warning btn-sm' do
           %span.icon-cross
           Archive
+      - elsif voucher.archived? && current_user.can_edit_vouchers
+        = link_to restore_program_sub_program_archived_voucher_path(id: voucher.id), method: :patch, data: {confirm: "Are you sure you want to restore this voucher?"}, class: 'btn btn-warning btn-sm' do
+          %span.icon-plus
+          Restore

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,11 @@ Rails.application.routes.draw do
         patch 'bulk_update', on: :collection
         delete :unavailable, on: :member
       end
+      resources :archived_vouchers, only: [:index, :create, :update, :destroy] do
+        patch 'bulk_update', on: :collection
+        delete :unavailable, on: :member
+        patch 'restore', on: :member
+      end
       resource :program_details, only: [:edit, :update]
       resources :unit_for_building, only: [:new, :edit, :create, :update]
     end


### PR DESCRIPTION
[//]: # 'remove this if PR is for a release-* branch'
# _Please squash merge this PR_

## Description

Add a new tab in the Program's Vouchers/Units section to show the archived vouchers. These vouchers can now be restored.

![Screenshot 2024-10-17 at 9 42 43 AM](https://github.com/user-attachments/assets/9ef4815b-9a56-478e-8597-6f2fb6da35c0)


## Type of change
[//]: # 'remove options that are not relevant'
- [X] New feature (adds functionality)

## Checklist before requesting review
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (rubocop)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
