### PR TITLE
prevent archived vouchers from showing n non-archived tabs

### DIFF
--- a/app/controllers/in_progress_vouchers_controller.rb
+++ b/app/controllers/in_progress_vouchers_controller.rb
@@ -9,7 +9,7 @@ class InProgressVouchersController < VouchersController
     @show_search = true
     @vouchers = @subprogram.vouchers.order(:id)
     @search = search_setup(scope: :client_search)
-    @vouchers_for_page = @search.select { |v| v.status_match.present? && v.status_match.active }
+    @vouchers_for_page = @search.select { |v| v.status_match.present? && v.status_match.active && !v.archived? }
     if @search_string.present?
       @vouchers_for_page = @vouchers_for_page.select { |v| v.status_match.present? && !v.status_match.confidential? }
       @voucher_state = 'matching in-progress'

--- a/app/controllers/successful_vouchers_controller.rb
+++ b/app/controllers/successful_vouchers_controller.rb
@@ -9,7 +9,7 @@ class SuccessfulVouchersController < VouchersController
     @show_search = true
     @vouchers = @subprogram.vouchers.order(:id)
     @search = search_setup(scope: :client_search)
-    @vouchers_for_page = @search.select { |v| v.status_match.present? && v.status_match.successful? }
+    @vouchers_for_page = @search.select { |v| v.status_match.present? && v.status_match.successful? && !v.archived? }
     if @search_string.present?
       @vouchers_for_page = @vouchers_for_page.select { |v| v.status_match.present? && !v.status_match.confidential? }
       @voucher_state = 'matching successful'

--- a/app/controllers/vouchers_controller.rb
+++ b/app/controllers/vouchers_controller.rb
@@ -19,7 +19,7 @@ class VouchersController < ApplicationController
 
   def index
     @vouchers = @subprogram.vouchers.order(:id)
-    @vouchers_for_page = @vouchers.select { |v| v.status_match.blank? && v.archived_at.blank? }
+    @vouchers_for_page = @vouchers.select { |v| v.status_match.blank? && !v.archived? }
     @voucher_state = 'available or unmatched'
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Part 2 to https://github.com/greenriver/boston-cas/pull/867

This update prevents vouchers that have been archived from showing up in any of the other tabs. They should now only be showin in the "Archived" tab.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
