### PR TITLE
New PSH Route expiration adjustments

### DIFF
--- a/app/controllers/match_decisions_controller.rb
+++ b/app/controllers/match_decisions_controller.rb
@@ -213,7 +213,8 @@ class MatchDecisionsController < ApplicationController
   end
 
   private def decision_params
-    @decision.whitelist_params_for_update params
+    d_p = @decision.whitelist_params_for_update(params)
+    d_p.merge!(params.require(:decision).permit(:shelter_expiration)) if can_reject_matches?
   end
 
   private def match_contacts_params

--- a/app/models/concerns/match_decisions/route_thirteen_cancel_reasons.rb
+++ b/app/models/concerns/match_decisions/route_thirteen_cancel_reasons.rb
@@ -12,6 +12,7 @@ module MatchDecisions
       [
         'MatchDecisions::Thirteen::ThirteenClientMatch',
         'MatchDecisions::Thirteen::ThirteenMatchAcknowledgement',
+        'MatchDecisions::Thirteen::ThirteenClientReview',
       ].include?(type)
     end
 
@@ -24,7 +25,7 @@ module MatchDecisions
         reasons << 'Incarcerated'
         reasons << 'Institutionalized'
         reasons << 'In Treatment/Recovery Center'
-        reasons << 'Match expired' unless pre_hsa_decision? || match_success_decision?
+        reasons << 'Match expired' if pre_hsa_decision?
         reasons << 'Client has declined match' unless pre_hsa_decision?
         reasons << 'Client has disengaged' unless pre_hsa_decision?
         reasons << 'Client has disappeared' unless pre_hsa_decision?

--- a/app/models/match_decisions/thirteen/thirteen_accept_referral.rb
+++ b/app/models/match_decisions/thirteen/thirteen_accept_referral.rb
@@ -69,6 +69,10 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_client_match.rb
+++ b/app/models/match_decisions/thirteen/thirteen_client_match.rb
@@ -80,6 +80,10 @@ module MatchDecisions::Thirteen
       end
     end
 
+    def expires?
+      true
+    end
+
     class StatusCallbacks < StatusCallbacks
       def pending
       end

--- a/app/models/match_decisions/thirteen/thirteen_client_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_client_review.rb
@@ -10,7 +10,12 @@ module MatchDecisions::Thirteen
     include MatchDecisions::RouteThirteenCancelReasons
     include MatchDecisions::RouteThirteenDeclineReasons
 
+    # proxy for client.release_of_information
+    attr_accessor :release_of_information
+
     validate :ensure_required_contacts_present_on_accept
+    validate :release_of_information_present_if_match_accepted
+    validate :spoken_with_services_agency_and_cori_release_submitted_if_accepted
 
     def to_partial_path
       'match_decisions/thirteen/client_review'
@@ -74,11 +79,32 @@ module MatchDecisions::Thirteen
       saved_status == 'pending' && status == 'accepted'
     end
 
+    def permitted_params
+      super + [:client_spoken_with_services_agency, :cori_release_form_submitted, :release_of_information, :shelter_expiration]
+    end
+
+    private def release_of_information_present_if_match_accepted
+      # if the Shelter Agency has just indicated a release has been signed:
+      # release_of_information = '1'
+      # if the client previously signed the release
+      # release_of_information = Time
+      errors.add :release_of_information, 'Client must provide a release of information to move forward in the match process' if status == 'accepted' && release_of_information == '0'
+    end
+
+    private def spoken_with_services_agency_and_cori_release_submitted_if_accepted
+      if status == 'accepted' # rubocop:disable Style/GuardClause
+        errors.add :client_spoken_with_services_agency, 'Communication with the services agency is required.' unless client_spoken_with_services_agency
+        errors.add :cori_release_form_submitted, 'A CORI release form is required.' if Config.get(:require_cori_release) && ! cori_release_form_submitted
+      end
+    end
+
     class StatusCallbacks < StatusCallbacks
       def pending
       end
 
       def accepted
+        # Only update the client's release_of_information attribute if we just set it
+        match.client.update_attribute(:release_of_information, Time.current) if @decision.release_of_information == '1'
         if match.sub_program.cori_hearing_required?
           @decision.next_step.initialize_decision!
         else

--- a/app/models/match_decisions/thirteen/thirteen_client_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_client_review.rb
@@ -68,6 +68,14 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def expires?
+      true
+    end
+
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
@@ -72,6 +72,10 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
@@ -60,6 +60,10 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def stallable?
+      true
+    end
+
     class StatusCallbacks < StatusCallbacks
       def pending
       end

--- a/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
@@ -72,6 +72,10 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
@@ -63,6 +63,10 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_match_acknowledgement.rb
+++ b/app/models/match_decisions/thirteen/thirteen_match_acknowledgement.rb
@@ -58,6 +58,14 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
+    def expires?
+      true
+    end
+
+    def stallable?
+      true
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/views/match_decisions/thirteen/_client_review.haml
+++ b/app/views/match_decisions/thirteen/_client_review.haml
@@ -1,6 +1,7 @@
 .match-decision.c-card.c-card--flush.card--block
   .c-card__content
     = simple_form_for @decision, url: access_context.match_decision_path(@match, @decision) do |form|
+      = render 'match_decisions/shelter_agency_expiration', form: form
       .o-choose.o-choose--flush.o-choose--flush-top
         .o-choose__choice{class: [('o-choose__choice--disabled' if !@decision.editable?)]}
           %header
@@ -12,6 +13,29 @@
             %p
               %i.icon-info
               If the match is accepted, all involved parties will be notified.
+            - if Config.get(:limit_client_names_on_matches)
+              - if @match.client.release_of_information.blank? && (@match.client.housing_release_status.blank? || @match.client.housing_release_status.downcase == 'none on file')
+                = form.input :release_of_information, as: :boolean, required: true, inline_label: 'Client has signed release of information to share their data with network partners'
+              - elsif @match.client.release_of_information.present?
+                %p
+                  Client signed release of information to share their data with network partners on
+                  %strong
+                    = @match.client.release_of_information.to_date
+                = form.input :release_of_information, as: :hidden, input_html: { value: @match.client.release_of_information}
+              - else
+                %p
+                  %strong
+                    = checkmark(true)
+                    Client provided a
+                    = Translation.translate(@match.client.housing_release_status)
+            = form.input :client_spoken_with_services_agency, as: :boolean, required: true, inline_label: "Client has spoken to a #{Translation.translate('shelter case manager')} and understands the services attached and the program requirements"
+            - if Config.get(:require_cori_release)
+              = form.input :cori_release_form_submitted, as: :boolean, required: true, inline_label: 'Client has submitted a CORI release form'
+            %p
+              = Translation.translate('The client does not need to be document-ready in order to indicate interest.')
+              %br
+              = "#{Translation.translate('When you indicate interest, notification will be sent to the')} #{Translation.translate('Housing Subsidy Administrator')}. If the #{Translation.translate('HSA')} has a release, #{Translation.translate('they can proceed to determine whether a criminal background hearing is needed. You will be notified when they either accept the match or schedule a hearing.')}"
 
-            = render 'match_decisions/continue_button', text: 'Accept Match', icon: 'checkmark', button_attributes: { class: 'btn btn-success jAccept', data: {submit_param_name: 'decision[status]', submit_param_value: 'accepted'}, disabled: (!@decision.editable?) }
+            = render 'match_decisions/continue_button', text: 'Indicate Interest in Match', icon: 'checkmark', button_attributes: {class: 'btn btn-success jNeedsToAgree', data: {submit_param_name: 'decision[status]', submit_param_value: 'accepted', toggle: 'modal', target: '#shelter-agency-modal'}, disabled: !(@decision.editable?)}
         = render 'match_decisions/decline_and_cancel_backup_actions', form: form, action_message: "If the match is declined, the #{Translation.translate('CoC Thirteen')} will be informed of the decision."
+      = render 'match_decisions/shelter_agency_agreement'

--- a/app/views/match_decisions/thirteen/_match_acknowledgement.haml
+++ b/app/views/match_decisions/thirteen/_match_acknowledgement.haml
@@ -1,15 +1,7 @@
 .match-decision.c-card.c-card--flush.card--block
   .c-card__content
     = simple_form_for @decision, url: access_context.match_decision_path(@match, @decision) do |form|
-      - if @match.shelter_expiration?
-        - if @match.shelter_expiration >= Date.current
-          %p
-            This match will expire if the client has not expressed interest in the match before
-            %strong= "#{@match.shelter_expiration}."
-        - else
-          %p
-            This match expired on
-            %strong= "#{@match.shelter_expiration}."
+      = render 'match_decisions/shelter_agency_expiration', form: form
       - if ! @match.shelter_expiration? || @match.shelter_expiration >= Date.current || can_reject_matches?
         .o-choose.o-choose--flush
           .o-choose__choice


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
Items from https://github.com/open-path/Green-River/issues/7131
* Fixes logic for exposing the Match expired cancel reason
* Adds the ability to update the expiration date on steps 1, 2, and 3.
* Adds expiration functionality to step 3

Items from https://github.com/open-path/Green-River/issues/7100
* Indicates which steps expire on route 13
* Indicates which steps stall on route 13
* Exposes expirations and stall status on the route 13 list page

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
