### PR TITLE
When the initial contact can't see the possible matches, don't send a link

### DIFF
--- a/app/models/notifications/match_initiation_for_manual_notification.rb
+++ b/app/models/notifications/match_initiation_for_manual_notification.rb
@@ -6,15 +6,19 @@
 
 module Notifications
   class MatchInitiationForManualNotification < Notifications::Base
-
     def self.create_for_match! match
       match.send(match.match_route.initial_contacts_for_match).each do |contact|
+        # this notification includes a link to the un-started matches, don't send anything
+        # if the user can't access the link
+        user = contact.user
+        next unless user&.can_see_alternate_matches? || user&.can_see_all_alternate_matches?
+
         create! match: match, recipient: contact
       end
     end
 
     def event_label
-      "Initial contacts notified of manual match"
+      'Initial contacts notified of manual match'
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* When:
  * matches are not set to auto start
  * but someone is set as the the default contact type for the route
  * but doesn't have permission to see the list of prioritized clients
  * don't send them an email

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
