### PR TITLE
Expose status updates

### DIFF
--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class ClientOpportunityMatch < ApplicationRecord
   include Matching::HasOrInheritsRequirements
   include HasOrInheritsServices
@@ -904,6 +906,27 @@ class ClientOpportunityMatch < ApplicationRecord
     join_model ||= client_opportunity_match_contacts.build contact: contact
     join_model.send("#{role}=", true)
     join_model.save
+  end
+
+  def status_update_details
+    data = status_updates.order(created_at: :desc).preload(:decision).map do |m|
+      response_text = m.response
+      still_active = if m.decision.still_active_responses.include?(response_text)
+        'Engaging'
+      else
+        'Not Engaging'
+      end
+      # We can't currently tell if this was positive or negative when someone chose other
+      still_active = 'Other' if response_text.downcase == 'other'
+      {
+        still_active: still_active,
+        response_date: m.created_at.to_date,
+        response: response_text,
+        decision: m.decision.label,
+      }
+    end
+    # data.group_by { |m| m[:still_active] }.transform_values(&:count)
+    data.group_by { |m| m[:still_active] }
   end
 
   private def add_default_dnd_staff_contacts!

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -908,6 +908,16 @@ class ClientOpportunityMatch < ApplicationRecord
     join_model.save
   end
 
+  ##
+  # Retrieves details of status updates for the match from when it was stalled.
+  #
+  # @return [Hash] A hash grouping status updates by engagement status ('Engaging', 'Not Engaging', 'Other'),
+  #   with each containing an array of hashes detailing:
+  #   - `:still_active` [String] - Engagement status.
+  #   - `:response_date` [Date] - Date of the response.
+  #   - `:response` [String] - Response text.
+  #   - `:decision` [String] - Label of the decision.
+  #
   def status_update_details
     data = status_updates.order(created_at: :desc).preload(:decision).map do |m|
       response_text = m.response
@@ -925,7 +935,6 @@ class ClientOpportunityMatch < ApplicationRecord
         decision: m.decision.label,
       }
     end
-    # data.group_by { |m| m[:still_active] }.transform_values(&:count)
     data.group_by { |m| m[:still_active] }
   end
 

--- a/app/views/match_decisions/_cancel_tab_content.haml
+++ b/app/views/match_decisions/_cancel_tab_content.haml
@@ -9,7 +9,7 @@
       %button{ class: 'btn btn-warning jCancel', data: cancel_data, disabled: !@decision.editable? }
         %i.icon-minus-circle
         Cancel Match
-
+  = render 'match_decisions/status_update_history'
 = content_for :page_js do
   :javascript
     new window.App.SingleOptionCheckboxes( $('form.edit_decision')[0], 'decision[administrative_cancel_reason_id][]')

--- a/app/views/match_decisions/_status_update_history.haml
+++ b/app/views/match_decisions/_status_update_history.haml
@@ -7,7 +7,7 @@
       %thead
         %tr
           %th{style: 'width: 8rem;'} Date
-          %th Decision
+          %th Match Step
           %th{style: 'width: 12rem;'} Update
       %tbody
         - details.each do |row|

--- a/app/views/match_decisions/_status_update_history.haml
+++ b/app/views/match_decisions/_status_update_history.haml
@@ -1,0 +1,17 @@
+- data = @match.status_update_details
+- if data.present?
+  %h2 Status Updates
+  - data.each do |label, details|
+    %h3 #{label} (#{details.count})
+    %table.table
+      %thead
+        %tr
+          %th{style: 'width: 8rem;'} Date
+          %th Decision
+          %th{style: 'width: 12rem;'} Update
+      %tbody
+        - details.each do |row|
+          %tr
+            %td= row[:response_date].try(:strftime, '%m/%d/%Y')
+            %td= row[:decision]
+            %td= row[:response]


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Exposes a list of status updates (from stalled matches) on the match page near the cancelation button

<img width="623" alt="Screenshot 2025-03-11 at 4 33 11 PM" src="https://github.com/user-attachments/assets/b1c07130-2d7b-45b0-9122-822d477094d1" />


## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
*New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

