### PR TITLE
clean up fuzz for TC HAT dob so it alwasy falls within the age range

### DIFF
--- a/app/models/concerns/tc_hat_calculations.rb
+++ b/app/models/concerns/tc_hat_calculations.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module TcHatCalculations
   extend ActiveSupport::Concern
 
@@ -41,8 +43,21 @@ module TcHatCalculations
       range = age_ranges.dig(hoh_age, :range)
       return unless range.present?
 
-      fuzz = -10..10
-      rand(range).years.ago.to_date + rand(fuzz).days
+      fuzz = -50..50
+      value = rand(range)
+      if value == range.first
+        # When value is the first year in the range, we only want to SUBTRACT days
+        # This will ensure the age is at least the minimum age in the range.
+        # e.g. running on Jan 1, 2025, 17 years ago would be 2008-01-01. If we add
+        # 50 days, the dob would be 2008-02-20 which would make the client 16 years old.
+        # If we subtracting 50 days would make the date 2007-11-30 which would make the
+        # client's age 17 years.
+        fuzz = -50..-1
+      elsif value == range.last
+        # Do the opposite of the above for the other end of the range
+        fuzz = 1..50
+      end
+      value.years.ago.to_date + rand(fuzz).days
     end
 
     private def age_ranges

--- a/spec/models/deidentified_tc_hat_spec.rb
+++ b/spec/models/deidentified_tc_hat_spec.rb
@@ -1,0 +1,37 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeidentifiedTcHat, type: :model do
+  describe 'Fuzzed dates of birth' do
+    let!(:assessment) { DeidentifiedTcHat.new }
+    let!(:age_ranges) { assessment.send(:age_ranges) }
+    it 'fall within the expected date range' do
+      age_ranges.each do |k, v|
+        # Skip nil keys which are used for the "unknown" age range
+        next if k.nil?
+
+        # Set the age of head of household age to the current key
+        assessment.hoh_age = k.to_s
+        # calculate the earliest and latest date of birth based on the age range
+        earliest_dob = (Date.current - v[:range].last.years)
+        latest_dob = (Date.current - v[:range].first.years)
+
+        # Date of birth is being fuzzed. We are running this test 10,000 times
+        # to get a probablily that we hit as many instances of the range as possible
+        # and to account for the randomness of the fuzzing.
+        # This is not a perfect test, but it should give us a good indication
+        # that the fuzzing is working as expected.
+        10_000.times do
+          expect(assessment.date_of_birth).to be_between(earliest_dob, latest_dob)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
The TC_HAT assessment fuzzed dates of birth were able to fall outside of the expected date range. This update lets the fuzzed dob calculation to corrrectly account for the date fuzzing on the first and last years in the range.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
