### PR TITLE
Setup stall contact relationships for various route 13 decisions

### DIFF
--- a/app/mailers/notifications_mailer.rb
+++ b/app/mailers/notifications_mailer.rb
@@ -279,6 +279,11 @@ class NotificationsMailer < DatabaseMailer
     mail(to: @contact.email, subject: 'Match ready for review - Requires Your Action')
   end
 
+  def set_asides_hsa_accepts_client_ssp(notification = nil)
+    setup_instance_variables(notification)
+    mail(to: @contact.email, subject: 'Match ready for review')
+  end
+
   # end Set Asides
 
   # Progress Updates

--- a/app/mailers/route_thirteen_mailer_methods.rb
+++ b/app/mailers/route_thirteen_mailer_methods.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module RouteThirteenMailerMethods
   extend ActiveSupport::Concern
   included do
@@ -22,12 +24,22 @@ module RouteThirteenMailerMethods
       mail(to: @contact.email, subject: 'New Housing Recommendation')
     end
 
+    def thirteen_match_acknowledgement_ssp(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: 'New Housing Recommendation')
+    end
+
     def thirteen_client_review_shelter_agency(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: 'Match Acknowledged - Requires Your Action')
     end
 
     def thirteen_client_review_hsa(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: 'Match Acknowledged')
+    end
+
+    def thirteen_client_review_ssp(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: 'Match Acknowledged')
     end
@@ -52,6 +64,11 @@ module RouteThirteenMailerMethods
       mail(to: @contact.email, subject: "Match Accepted by #{Translation.translate('Shelter Agency Thirteen')} - Requires Your Action")
     end
 
+    def thirteen_hearing_scheduled_ssp(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: "Match Accepted by #{Translation.translate('Shelter Agency Thirteen')}")
+    end
+
     def thirteen_hearing_scheduled_dnd_staff(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: "Match Accepted by #{Translation.translate('Shelter Agency Thirteen')}")
@@ -72,6 +89,11 @@ module RouteThirteenMailerMethods
       mail(to: @contact.email, subject: "Match Review Scheduled by #{Translation.translate('HSA Thirteen')} - Requires Your Action")
     end
 
+    def thirteen_hearing_outcome_ssp(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: "Match Review Scheduled by #{Translation.translate('HSA Thirteen')}")
+    end
+
     def thirteen_hearing_outcome_dnd_staff(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: "Match Review Scheduled by #{Translation.translate('HSA Thirteen')}")
@@ -90,6 +112,11 @@ module RouteThirteenMailerMethods
     def thirteen_hsa_review_hsa(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: "Match Ready for Review by #{Translation.translate('HSA Thirteen')} - Requires Your Action")
+    end
+
+    def thirteen_hsa_review_ssp(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: "Match Ready for Review by #{Translation.translate('HSA Thirteen')}")
     end
 
     def thirteen_hsa_review_dnd_staff(notification = nil)
@@ -133,6 +160,11 @@ module RouteThirteenMailerMethods
     end
 
     def thirteen_confirm_match_success_hsa(notification = nil)
+      setup_instance_variables(notification)
+      mail(to: @contact.email, subject: 'Match Success Confirmed')
+    end
+
+    def thirteen_confirm_match_success_ssp(notification = nil)
       setup_instance_variables(notification)
       mail(to: @contact.email, subject: 'Match Success Confirmed')
     end

--- a/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
+++ b/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::HomelessSetAside
   class SetAsidesHsaAcceptsClient < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -65,6 +67,7 @@ module MatchDecisions::HomelessSetAside
     def notifications_for_this_step
       @notifications_for_this_step ||= [].tap do |m|
         m << Notifications::HomelessSetAside::HsaAcceptsClient
+        m << Notifications::HomelessSetAside::HsaAcceptsClientSspNotification
       end
     end
 

--- a/app/models/match_decisions/provider_only/hsa_accepts_client.rb
+++ b/app/models/match_decisions/provider_only/hsa_accepts_client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::ProviderOnly
   class HsaAcceptsClient < ::MatchDecisions::Base
     def to_partial_path
@@ -75,6 +77,7 @@ module MatchDecisions::ProviderOnly
     def notifications_for_this_step
       @notifications_for_this_step ||= [].tap do |m|
         m << Notifications::ProviderOnly::HsaAcceptsClient
+        m << Notifications::ProviderOnly::HsaAcceptsClientSspNotification
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_accept_referral.rb
+++ b/app/models/match_decisions/thirteen/thirteen_accept_referral.rb
@@ -79,6 +79,16 @@ module MatchDecisions::Thirteen
       true
     end
 
+    def stalled_contact_types
+      @stalled_contact_types ||= [
+        :shelter_agency_contacts,
+        :housing_subsidy_admin_contacts,
+        :dnd_staff_contacts,
+        :ssp_contacts,
+        :do_contacts,
+      ]
+    end
+
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_client_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_client_review.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenClientReview < Base
     include MatchDecisions::AcceptsDeclineReason
@@ -39,6 +41,7 @@ module MatchDecisions::Thirteen
         m << Notifications::Thirteen::ThirteenClientReviewShelterAgency
         m << Notifications::Thirteen::ThirteenClientReviewHsa
         m << Notifications::Thirteen::ThirteenClientReviewDndStaff
+        m << Notifications::Thirteen::ThirteenClientReviewSsp
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_confirm_match_success.rb
+++ b/app/models/match_decisions/thirteen/thirteen_confirm_match_success.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenConfirmMatchSuccess < Base
     include MatchDecisions::RouteEightCancelReasons
@@ -59,6 +61,7 @@ module MatchDecisions::Thirteen
         m << Notifications::Thirteen::ThirteenConfirmMatchSuccessHsa
         m << Notifications::Thirteen::ThirteenConfirmMatchSuccessShelterAgency
         m << Notifications::Thirteen::ThirteenConfirmMatchSuccessDndStaff
+        m << Notifications::Thirteen::ThirteenConfirmMatchSuccessSsp
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
@@ -41,6 +41,7 @@ module MatchDecisions::Thirteen
         m << Notifications::Thirteen::ThirteenHearingOutcomeShelterAgency
         m << Notifications::Thirteen::ThirteenHearingOutcomeHsa
         m << Notifications::Thirteen::ThirteenHearingOutcomeDndStaff
+        m << Notifications::Thirteen::ThirteenHearingOutcomeSsp
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenHearingOutcome < Base
     include MatchDecisions::AcceptsDeclineReason
@@ -74,6 +76,16 @@ module MatchDecisions::Thirteen
 
     def stallable?
       true
+    end
+
+    def stalled_contact_types
+      @stalled_contact_types ||= [
+        :shelter_agency_contacts,
+        :housing_subsidy_admin_contacts,
+        :dnd_staff_contacts,
+        :ssp_contacts,
+        :do_contacts,
+      ]
     end
 
     private def ensure_required_contacts_present_on_accept

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
@@ -62,10 +62,6 @@ module MatchDecisions::Thirteen
       send_notifications_for_step if send_notifications
     end
 
-    def stallable?
-      false
-    end
-
     class StatusCallbacks < StatusCallbacks
       def pending
       end

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenHearingOutcomeDecline < Base
     include MatchDecisions::AcceptsDeclineReason
@@ -62,6 +64,16 @@ module MatchDecisions::Thirteen
 
     def stallable?
       true
+    end
+
+    def stalled_contact_types
+      @stalled_contact_types ||= [
+        :shelter_agency_contacts,
+        :housing_subsidy_admin_contacts,
+        :dnd_staff_contacts,
+        :ssp_contacts,
+        :do_contacts,
+      ]
     end
 
     class StatusCallbacks < StatusCallbacks

--- a/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_outcome_decline.rb
@@ -63,17 +63,7 @@ module MatchDecisions::Thirteen
     end
 
     def stallable?
-      true
-    end
-
-    def stalled_contact_types
-      @stalled_contact_types ||= [
-        :shelter_agency_contacts,
-        :housing_subsidy_admin_contacts,
-        :dnd_staff_contacts,
-        :ssp_contacts,
-        :do_contacts,
-      ]
+      false
     end
 
     class StatusCallbacks < StatusCallbacks

--- a/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
@@ -41,6 +41,7 @@ module MatchDecisions::Thirteen
         m << Notifications::Thirteen::ThirteenHearingScheduledShelterAgency
         m << Notifications::Thirteen::ThirteenHearingScheduledHsa
         m << Notifications::Thirteen::ThirteenHearingScheduledDndStaff
+        m << Notifications::Thirteen::ThirteenHearingScheduledSsp
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hearing_scheduled.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenHearingScheduled < Base
     include MatchDecisions::AcceptsDeclineReason
@@ -74,6 +76,16 @@ module MatchDecisions::Thirteen
 
     def stallable?
       true
+    end
+
+    def stalled_contact_types
+      @stalled_contact_types ||= [
+        :shelter_agency_contacts,
+        :housing_subsidy_admin_contacts,
+        :dnd_staff_contacts,
+        :ssp_contacts,
+        :do_contacts,
+      ]
     end
 
     private def ensure_required_contacts_present_on_accept

--- a/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
@@ -36,6 +36,7 @@ module MatchDecisions::Thirteen
         m << Notifications::Thirteen::ThirteenHsaReviewShelterAgency
         m << Notifications::Thirteen::ThirteenHsaReviewHsa
         m << Notifications::Thirteen::ThirteenHsaReviewDndStaff
+        m << Notifications::Thirteen::ThirteenHsaReviewSsp
       end
     end
 

--- a/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
+++ b/app/models/match_decisions/thirteen/thirteen_hsa_review.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenHsaReview < Base
     include MatchDecisions::AcceptsDeclineReason
@@ -67,6 +69,15 @@ module MatchDecisions::Thirteen
       true
     end
 
+    def stalled_contact_types
+      @stalled_contact_types ||= [
+        :shelter_agency_contacts,
+        :housing_subsidy_admin_contacts,
+        :dnd_staff_contacts,
+        :ssp_contacts,
+        :do_contacts,
+      ]
+    end
     private def ensure_required_contacts_present_on_accept
       missing_contacts = []
       missing_contacts << "a #{Translation.translate('Shelter Agency Thirteen')} Contact" if save_will_accept? && match.shelter_agency_contacts.none?

--- a/app/models/match_decisions/thirteen/thirteen_match_acknowledgement.rb
+++ b/app/models/match_decisions/thirteen/thirteen_match_acknowledgement.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Thirteen
   class ThirteenMatchAcknowledgement < Base
     include MatchDecisions::RouteThirteenCancelReasons
@@ -31,6 +33,7 @@ module MatchDecisions::Thirteen
       @notifications_for_this_step ||= [].tap do |m|
         m << Notifications::Thirteen::ThirteenMatchAcknowledgementShelterAgency
         m << Notifications::Thirteen::ThirteenMatchAcknowledgementHsa
+        m << Notifications::Thirteen::ThirteenMatchAcknowledgementSsp
       end
     end
 

--- a/app/models/notifications/homeless_set_aside/hsa_decision_hsp.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_decision_hsp.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module Notifications::HomelessSetAside
   class HsaDecisionHsp < ::Notifications::Base
     # Notification sent to a client of a decision made by the housing subsidy administrator
@@ -17,6 +19,5 @@ module Notifications::HomelessSetAside
     def event_label
       "#{Translation.translate('Housing Search Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end
-
   end
 end

--- a/app/models/notifications/thirteen/thirteen_client_review_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenClientReviewSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_client_review_decision
+    end
+
+    def event_label
+      "#{Translation.translate('HSA Thirteen')} notified of acknowledged match."
+    end
+  end
+end

--- a/app/models/notifications/thirteen/thirteen_confirm_match_success_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_confirm_match_success_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenConfirmMatchSuccessSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_hsa_review_decision
+    end
+
+    def event_label
+      "#{Translation.translate('HSA Thirteen')} notified of referral acceptance."
+    end
+  end
+end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenHearingOutcomeSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_hearing_outcome_decision
+    end
+
+    def event_label
+      "#{Translation.translate('HSA Thirteen')} notified to submit hearing outcome."
+    end
+  end
+end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenHearingScheduledSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_hearing_scheduled_decision
+    end
+
+    def event_label
+      "#{Translation.translate('HSA Thirteen')} notified to schedule CORI review."
+    end
+  end
+end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenHsaReviewSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_hsa_review_decision
+    end
+
+    def event_label
+      "#{Translation.translate('HSA Thirteen')} notified to submit their review."
+    end
+  end
+end

--- a/app/models/notifications/thirteen/thirteen_match_acknowledgement_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_match_acknowledgement_ssp.rb
@@ -1,0 +1,25 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Notifications::Thirteen
+  class ThirteenMatchAcknowledgementSsp < ::Notifications::Base
+    def self.create_for_match! match
+      match.ssp_contacts.each do |contact|
+        create! match: match, recipient: contact
+      end
+    end
+
+    def decision
+      match.thirteen_match_acknowledgement_decision
+    end
+
+    def event_label
+      "#{Translation.translate('Shelter Agency Thirteen')} notified of match."
+    end
+  end
+end

--- a/app/views/notifications_mailer/thirteen_client_review_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_client_review_ssp.text.haml
@@ -1,6 +1,8 @@
 Hello #{@contact.full_name},
 \
-The following match has been accepted by the #{Translation.translate('HSA')}:
+The match is has been acknowledged by the #{Translation.translate('Shelter Agency Thirteen')} contacts and is currently in review.
+\
+Please review details:
 #{notification_match_url @notification, @match}
 \
 = render 'client_details'

--- a/app/views/notifications_mailer/thirteen_confirm_match_success_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_confirm_match_success_ssp.text.haml
@@ -1,7 +1,6 @@
 Hello #{@contact.full_name},
-\
-The following match has been accepted by the #{Translation.translate('HSA')}:
-#{notification_match_url @notification, @match}
+
+= "The match now requires final approval from #{Translation.translate('CoC Thirteen')} staff to complete."
 \
 = render 'client_details'
 \

--- a/app/views/notifications_mailer/thirteen_hearing_outcome_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_hearing_outcome_ssp.text.haml
@@ -1,0 +1,17 @@
+Hello #{@contact.full_name},
+\
+The #{Translation.translate('CORI hearing')} for this match has been scheduled by #{Translation.translate('Shelter Agency Thirteen')} contacts and is currently pending the outcome of this hearing being entered by #{Translation.translate('Shelter Agency Thirteen')}.
+\
+Please review details:
+#{notification_match_url @notification, @match}
+\
+= render 'client_details'
+\
+= render 'location_details'
+\
+= render 'program_details'
+\
+\
+\
+\
+= render 'email_footer'

--- a/app/views/notifications_mailer/thirteen_hearing_scheduled_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_hearing_scheduled_ssp.text.haml
@@ -1,6 +1,8 @@
 Hello #{@contact.full_name},
 \
-The following match has been accepted by the #{Translation.translate('HSA')}:
+The match is has been accepted by the #{Translation.translate('Shelter Agency Thirteen')} contacts and it is now ready for your action.
+\
+Please review details:
 #{notification_match_url @notification, @match}
 \
 = render 'client_details'

--- a/app/views/notifications_mailer/thirteen_hsa_review_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_hsa_review_ssp.text.haml
@@ -1,6 +1,8 @@
 Hello #{@contact.full_name},
 \
-The following match has been accepted by the #{Translation.translate('HSA')}:
+The match is pending the review by #{Translation.translate('HSA Thirteen')} - it is now ready for your action.
+\
+Please review details:
 #{notification_match_url @notification, @match}
 \
 = render 'client_details'

--- a/app/views/notifications_mailer/thirteen_match_acknowledgement_ssp.text.haml
+++ b/app/views/notifications_mailer/thirteen_match_acknowledgement_ssp.text.haml
@@ -1,0 +1,22 @@
+Hello #{@contact.full_name},
+\
+The CAS has generated a new match recommendation.
+\
+The match is pending acknowledgement by the #{Translation.translate('Shelter Agency Thirteen')} contacts.
+\
+- if @match.shelter_expiration.present?
+  = "#{Translation.translate('Shelter Agency Thirteen')} must acknowledge the match by #{@match.shelter_expiration}."
+  \
+Please review details:
+#{notification_match_url @notification, @match}
+\
+= render 'client_details'
+\
+= render 'location_details'
+\
+= render 'program_details'
+\
+\
+\
+\
+= render 'email_footer'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Add stalled match contact types for decisions that can stall
* Adds SSP contact notifications as specified here: https://github.com/open-path/Green-River/issues/7509
* Removes unneeded `stallable-ness` from CoC admin step
* Fixes a handful of existing notification that didn't include all four required parts:
  1. Entry in `notifications_for_this_step`
  2. Method in the mailer (or mailer concern)
  3. Notification class for the notification
  4. view for the mailer  

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

