### PR TITLE
Use days homeless for imported client score if no score is present

### DIFF
--- a/app/models/imported_client.rb
+++ b/app/models/imported_client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class ImportedClient < NonHmisClient
   has_one :project_client, -> do
     where(
@@ -34,7 +36,7 @@ class ImportedClient < NonHmisClient
       elsif first.present?
         where = search_first_name(first).or(search_alternate_name(first))
       end
-      # Explicity search for "first last"
+      # Explicitly search for "first last"
     elsif text.include?(' ')
       first, last = text.split(' ').map(&:strip)
       where = search_first_name(first).

--- a/app/models/imported_client_assessment.rb
+++ b/app/models/imported_client_assessment.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class ImportedClientAssessment < NonHmisAssessment
   validates :set_asides_housing_status, presence: true
   validates :days_homeless_in_the_last_three_years, presence: true, numericality: { less_than_or_equal_to: 1096 }
@@ -21,6 +23,10 @@ class ImportedClientAssessment < NonHmisAssessment
     {
       'ImportedClientAssessment' => title,
     }
+  end
+
+  def assessment_score
+    super || days_homeless_in_the_last_three_years
   end
 
   def self.client_table_headers(user)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Imported clients no longer include assessment scores in the import, but need to be prioritized, using days homeless in the past 3 years as a proxy for score.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

