### PR TITLE
7721 improve permission checks on non-hmis client and assessment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     ansi (1.5.0)
     anyway_config (2.7.2)
       ruby-next-core (~> 1.0)
-    ast (2.4.2)
+    ast (2.4.3)
     attribute_normalizer (1.2.0)
     authtrail (0.5.0)
       railties (>= 6.1)
@@ -295,7 +295,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.2)
+    connection_pool (2.5.3)
     crass (1.0.6)
     csv (3.3.2)
     daemons (1.4.1)
@@ -328,7 +328,7 @@ GEM
     dotenv-rails (3.1.0)
       dotenv (= 3.1.0)
       railties (>= 6.1)
-    drb (2.2.1)
+    drb (2.2.3)
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -410,7 +410,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.10.2)
+    json (2.12.2)
     jsonpath (1.1.5)
       multi_json
     kaminari (1.2.2)
@@ -425,7 +425,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    language_server-protocol (3.17.0.3)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     lograge (0.14.0)
       actionpack (>= 4)
@@ -496,10 +497,10 @@ GEM
     paper_trail (16.0.0)
       activerecord (>= 6.1)
       request_store (~> 1.4)
-    parallel (1.26.3)
+    parallel (1.27.0)
     paranoia (3.0.1)
       activerecord (>= 6, < 8.1)
-    parser (3.3.5.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
@@ -509,6 +510,7 @@ GEM
     pretender (0.5.0)
       actionpack (>= 6.1)
     prettyprint (0.2.0)
+    prism (1.4.0)
     prometheus-client (4.2.4)
       base64
     pry (0.15.2)
@@ -527,7 +529,7 @@ GEM
       nio4r (~> 2.0)
     pwned (2.4.1)
     racc (1.8.1)
-    rack (3.1.14)
+    rack (3.1.15)
     rack-mini-profiler (3.3.1)
       rack (>= 1.2.0)
     rack-session (2.1.1)
@@ -581,7 +583,7 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.24.0)
       connection_pool
-    regexp_parser (2.9.2)
+    regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
     request_store (1.7.0)
@@ -612,37 +614,33 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
-    rubocop (1.67.0)
+    rubocop (1.75.7)
       json (~> 2.3)
-      language_server-protocol (>= 3.17.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rubocop-ast (>= 1.32.2, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.33.0)
-      parser (>= 3.3.1.0)
-    rubocop-capybara (2.20.0)
-      rubocop (~> 1.41)
-    rubocop-factory_bot (2.25.1)
-      rubocop (~> 1.41)
-    rubocop-faker (1.1.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.44.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    rubocop-faker (1.3.0)
       faker (>= 2.12.0)
-      rubocop (>= 0.82.0)
-    rubocop-rails (2.24.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.72.1)
+    rubocop-rails (2.32.0)
       activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
       rack (>= 1.1)
-      rubocop (>= 1.33.0, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (2.29.1)
-      rubocop (~> 1.40)
-      rubocop-capybara (~> 2.17)
-      rubocop-factory_bot (~> 2.22)
-      rubocop-rspec_rails (~> 2.28)
-    rubocop-rspec_rails (2.28.3)
-      rubocop (~> 1.40)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rspec (3.6.0)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-filemagic (0.7.3)
     ruby-next-core (1.1.1)
     ruby-prof (1.7.1)
@@ -708,7 +706,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
-    unicode-display_width (2.6.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     uri (1.0.3)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
@@ -926,7 +926,7 @@ CHECKSUMS
   amazing_print (1.7.2) sha256=c89a1dfe4f8508c1e780871d51b8786efd100f625201f6e1d18a0d4dedaac702
   ansi (1.5.0) sha256=5408253274e33d9d27d4a98c46d2998266fd51cba58a7eb9d08f50e57ed23592
   anyway_config (2.7.2) sha256=30f6b087c0b41afdd43fe46c81d65a16f052a8489dab453abaeb4ea67aa74bad
-  ast (2.4.2) sha256=1e280232e6a33754cde542bc5ef85520b74db2aac73ec14acef453784447cc12
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   attribute_normalizer (1.2.0) sha256=580df3f316d7f0a2cc068fd655377f4769848643328d0c6c6c685ea98ac181c4
   authtrail (0.5.0) sha256=adeab5e6480f2bffe7532e952d4dc088569bf7a4c42d97c7737b7ebda59a768b
   auto-session-timeout (1.1) sha256=c6e83ae904bc8ade0b74d448674a4478b52903501f0a63dc50c98289e77c45d3
@@ -993,7 +993,7 @@ CHECKSUMS
   coffee-script (2.4.1) sha256=82fe281e11b93c8117b98c5ea8063e71741870f1c4fbb27177d7d6333dd38765
   coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (2.5.2) sha256=c121d090f8217911f960c7b628bf2bf1b1444f284fd854edc188821c4f602108
+  connection_pool (2.5.3) sha256=cfd74a82b9b094d1ce30c4f1a346da23ee19dc8a062a16a85f58eab1ced4305b
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   csv (3.3.2) sha256=6ff0c135e65e485d1864dde6c1703b60d34cc9e19bed8452834a0b28a519bd4e
   daemons (1.4.1) sha256=8fc76d76faec669feb5e455d72f35bd4c46dc6735e28c420afb822fac1fa9a1d
@@ -1009,7 +1009,7 @@ CHECKSUMS
   diff-lcs (1.6.1) sha256=12a5a83f3e37a8e2f4427268e305914d5f1879f22b4e73bb1a09f76a3dd86cd4
   dotenv (3.1.0) sha256=8b7e682e197dbaa69bd5660cc18bc821e8152e1bb2b3c02e32f2be718fd8b2b4
   dotenv-rails (3.1.0) sha256=d2e1bc7bf39acf7f135920c81306b1eb7dbfa27a4577fce7665488d77d7fe719
-  drb (2.2.1) sha256=e9d472bf785f558b96b25358bae115646da0dbfd45107ad858b0bc0d935cb340
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   dry-configurable (1.3.0) sha256=882d862858567fc1210d2549d4c090f34370fc1bb7c5c1933de3fe792e18afa8
   dry-core (1.1.0) sha256=0903821a9707649a7da545a2cd88e20f3a663ab1c5288abd7f914fa7751ab195
   dry-inflector (1.2.0) sha256=22f5d0b50fd57074ae57e2ca17e3b300e57564c218269dcf82ff3e42d3f38f2e
@@ -1043,14 +1043,15 @@ CHECKSUMS
   irb (1.15.2) sha256=222f32952e278da34b58ffe45e8634bf4afc2dc7aa9da23fed67e581aa50fdba
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   jquery-rails (4.6.0) sha256=3c4e6bf47274340b44d836b8aa1b5472c6d451e2739af5ec094421f39025a7e2
-  json (2.10.2) sha256=34e0eada93022b2a0a3345bb0b5efddb6e9ff5be7c48e409cfb54ff8a36a8b06
+  json (2.12.2) sha256=ba94a48ad265605c8fa9a50a5892f3ba6a02661aa010f638211f3cb36f44abf4
   jsonpath (1.1.5) sha256=29f70467193a2dc93ab864ec3d3326d54267961acc623f487340eb9c34931dbe
   k8s-ruby (0.16.0)
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
   kaminari-activerecord (1.2.2) sha256=0dd3a67bab356a356f36b3b7236bcb81cef313095365befe8e98057dd2472430
   kaminari-core (1.2.2) sha256=3bd26fec7370645af40ca73b9426a448d09b8a8ba7afa9ba3c3e0d39cdbb83ff
-  language_server-protocol (3.17.0.3) sha256=3d5c58c02f44a20d972957a9febe386d7e7468ab3900ce6bd2b563dd910c6b3f
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   lograge (0.14.0) sha256=42371a75823775f166f727639f5ddce73dd149452a55fc94b90c303213dc9ae1
   logstop (0.3.1) sha256=962055e109a74375c68f2bd2cbfe0b7b326939463242dc6c591235610c9b32a3
@@ -1087,14 +1088,15 @@ CHECKSUMS
   overcommit (0.63.0) sha256=d42e63eb8bfbca0dbcf5adef5264c77dd5f1981f128fed7f9bd7f668252ec414
   pagy (8.6.3) sha256=537b2ee3119f237dd6c4a0d0a35c67a77b9d91ebb9d4f85e31407c2686774fb2
   paper_trail (16.0.0) sha256=e9b9f0fb1b8b590c8231cfa931b282ba92f90e066e393930a5e1c61ae4c5019d
-  parallel (1.26.3) sha256=d86babb7a2b814be9f4b81587bf0b6ce2da7d45969fab24d8ae4bf2bb4d4c7ef
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   paranoia (3.0.1) sha256=cdb50c4c5c66f61fd1354f26371a8f0ca6d60156215bebffff42e135c495d083
-  parser (3.3.5.0) sha256=f30ebb71b7830c2e7cdc4b2b0e0ec2234900e3fca3fe2fba47f78be759181ab3
+  parser (3.3.8.0) sha256=2476364142b307fa5a1b1ece44f260728be23858a9c71078e956131a75453c45
   pg (1.5.9) sha256=761efbdf73b66516f0c26fcbe6515dc7500c3f0aa1a1b853feae245433c64fdc
   popper_js (1.16.1) sha256=6b102fb5ee86c5fa68a0c865547e66d9bf7e80a951053b21c72c3c92a587d692
   pp (0.6.2) sha256=947ec3120c6f92195f8ee8aa25a7b2c5297bb106d83b41baa02983686577b6ff
   pretender (0.5.0) sha256=02120f25bc1c2b98468e136cec9e841360935dcc291158195b0cd073ff8fad77
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.4.0) sha256=dc0e3e00e93160213dc2a65519d9002a4a1e7b962db57d444cf1a71565bb703e
   prometheus-client (4.2.4) sha256=d126a024ea068273008c2789bf2be87067fa5eb030f7540fe5d1a02260bbfe2f
   pry (0.15.2) sha256=12d54b8640d3fa29c9211dd4ffb08f3fd8bf7a4fd9b5a73ce5b59c8709385b6b
   pry-byebug (3.11.0) sha256=0b0abb7d309bc7f00044d512a3c8567274f7012b944b38becc8440439a1cea72
@@ -1104,7 +1106,7 @@ CHECKSUMS
   puma (6.6.0) sha256=f25c06873eb3d5de5f0a4ebc783acc81a4ccfe580c760cfe323497798018ad87
   pwned (2.4.1) sha256=e375b45e1cd78aded2c923737f75e09e64bc66582142c144bd85f4ce1fa0955d
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (3.1.14) sha256=84613c2a8df193bb6711d9c14ecc6d5a65a7cb4312379a65e793562608944b44
+  rack (3.1.15) sha256=d12b3e9960d18a26ded961250f2c0e3b375b49ff40dbe6786e9c3b160cbffca4
   rack-mini-profiler (3.3.1) sha256=2bf0de7d5795f54581e453b248e42cc50e8d0529efac73828653a9ad2407a801
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
@@ -1121,7 +1123,7 @@ CHECKSUMS
   redcarpet (3.6.0) sha256=8ad1889c0355ff4c47174af14edd06d62f45a326da1da6e8a121d59bdcd2e9e9
   redis (5.4.0) sha256=798900d869418a9fc3977f916578375b45c38247a556b61d58cba6bb02f7d06b
   redis-client (0.24.0) sha256=ee65ee39cb2c38608b734566167fd912384f3c1241f59075e22858f23a085dbb
-  regexp_parser (2.9.2) sha256=5a27e767ad634f8a4b544520d5cd28a0db7aa1198a5d7c9d7e11d7b3d9066446
+  regexp_parser (2.10.0) sha256=cb6f0ddde88772cd64bff1dbbf68df66d376043fe2e66a9ef77fcb1b0c548c61
   reline (0.6.1) sha256=1afcc9d7cb1029cdbe780d72f2f09251ce46d3780050f3ec39c3ccc6b60675fb
   request_store (1.7.0) sha256=e1b75d5346a315f452242a68c937ef8e48b215b9453a77a6c0acdca2934c88cb
   responders (3.1.1) sha256=92f2a87e09028347368639cfb468f5fefa745cb0dc2377ef060db1cdd79a341a
@@ -1133,14 +1135,11 @@ CHECKSUMS
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
-  rubocop (1.67.0) sha256=8ccca7226e76d0a9974af960ea446d1fb38adf0c491214294e2fed75a85c378c
-  rubocop-ast (1.33.0) sha256=6235809347985fc9019e44180de1be56885004a4f51a74512d0b70fe0c533ed5
-  rubocop-capybara (2.20.0) sha256=2a6844b942921f230ee3ab8c94fe77f41a9406096a140245270c0e11624bb938
-  rubocop-factory_bot (2.25.1) sha256=62751bde7af789878b8a31cbd2a82e69515ce7b23a2ad1820cb0fcc3e0150134
-  rubocop-faker (1.1.0) sha256=bfdd208f79cb96f124b1ceb2b4a9399fc1b61f2c078ea203eca0e08ee2ada215
-  rubocop-rails (2.24.1) sha256=03edf766954947468f3686cedb69142fae4f10e2007287f89cc0ea7072eeac19
-  rubocop-rspec (2.29.1) sha256=534ee81a3006e7379ec6203687ef7c06ca1d137b7d6d67c2777b680b1ce82e13
-  rubocop-rspec_rails (2.28.3) sha256=9769f2077cca8af2269193ba0450e0317ae1827a132c19149fdbeecaaca32818
+  rubocop (1.75.7) sha256=23566ebb25263f26020687f8abb8aec049f3e29b6a00bdf0aa9d1db16b558be9
+  rubocop-ast (1.44.1) sha256=e3cc04203b2ef04f6d6cf5f85fe6d643f442b18cc3b23e3ada0ce5b6521b8e92
+  rubocop-faker (1.3.0) sha256=cb9ac132d44f9d2db6d5f9f8f5714700bf4d272cbaef5bce4052f4270fdc5c9b
+  rubocop-rails (2.32.0) sha256=9fcc623c8722fe71e835e99c4a18b740b5b0d3fb69915d7f0777f00794b30490
+  rubocop-rspec (3.6.0) sha256=c0e4205871776727e54dee9cc91af5fd74578001551ba40e1fe1a1ab4b404479
   ruby-filemagic (0.7.3) sha256=9dedfac69c737be29efb4542a280e345a70ba2b6ba905a518abd9998c8f3a7d9
   ruby-next-core (1.1.1) sha256=37886d41cf91072a0f14fa53b3e7e650adce1fe3b1227842bae32034dcce1d5f
   ruby-prof (1.7.1) sha256=026393448cf92fd24a91739bf71ccd2bfe88fe8a1401ee8afc4948a16d62ea24
@@ -1174,7 +1173,8 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unf (0.1.4) sha256=4999517a531f2a955750f8831941891f6158498ec9b6cb1c81ce89388e63022e
   unf_ext (0.0.9.1) sha256=926114a858934126c6bbfd3254347dadb5dae354711869368c0f75e3765fc6e9
-  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  unicode-display_width (3.1.4) sha256=8caf2af1c0f2f07ec89ef9e18c7d88c2790e217c482bfc78aaa65eadd5415ac1
+  unicode-emoji (4.0.4) sha256=2c2c4ef7f353e5809497126285a50b23056cc6e61b64433764a35eff6c36532a
   uri (1.0.3) sha256=e9f2244608eea2f7bc357d954c65c910ce0399ca5e18a7a29207ac22d8767011
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451
   validates_email_format_of (1.8.2) sha256=e2dfcf3e933547d06c41dacf066c7b07614819439c8780c3a2521ce047052577

--- a/app/controllers/non_hmis_assessments_controller.rb
+++ b/app/controllers/non_hmis_assessments_controller.rb
@@ -149,24 +149,16 @@ class NonHmisAssessmentsController < ApplicationController
       client_id = params[:deidentified_client_id].to_i
       client_scope = DeidentifiedClient.deidentified
     else
-      raise 'unroutable, should not be reached'
+      raise 'unroutable, should not be reached' # Or handle as a bad request
     end
 
     @non_hmis_client = client_scope.visible_to(current_user).find(client_id)
+  rescue ActiveRecord::RecordNotFound
+    raise ActionController::RoutingError.new('Not Found') # Or handle as appropriate, e.g. redirect with flash
   end
 
   private def set_assessment
-    found = @non_hmis_client.assessments.find(params[:id].to_i)
-    allowed = false
-    case action_name
-    when :show
-      allowed = found.editable_by?(current_user)
-    when :edit, :update, :destroy, :unlock
-      allowed = found.viewable_by?(current_user)
-    end
-    raise ActionController::RoutingError.new('Not Found') unless allowed
-
-    @assessment = found
+    @assessment = @non_hmis_client.assessments.find(params[:id].to_i)
   end
 
   private def set_neighborhoods

--- a/app/controllers/non_hmis_assessments_controller.rb
+++ b/app/controllers/non_hmis_assessments_controller.rb
@@ -149,12 +149,10 @@ class NonHmisAssessmentsController < ApplicationController
       client_id = params[:deidentified_client_id].to_i
       client_scope = DeidentifiedClient.deidentified
     else
-      raise 'unroutable, should not be reached' # Or handle as a bad request
+      raise 'unroutable, should not be reached'
     end
 
     @non_hmis_client = client_scope.visible_to(current_user).find(client_id)
-  rescue ActiveRecord::RecordNotFound
-    raise ActionController::RoutingError.new('Not Found') # Or handle as appropriate, e.g. redirect with flash
   end
 
   private def set_assessment

--- a/app/controllers/non_hmis_assessments_controller.rb
+++ b/app/controllers/non_hmis_assessments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -138,8 +140,19 @@ class NonHmisAssessmentsController < ApplicationController
   end
 
   private def set_client
-    client_id = (params[:identified_client_id] || params[:deidentified_client_id]).to_i
-    @non_hmis_client = NonHmisClient.visible_to(current_user).find(client_id)
+    client_scope = nil
+    client_id = nil
+    if params[:identified_client_id]
+      client_id = params[:identified_client_id].to_i
+      client_scope = IdentifiedClient.identified
+    elsif params[:deidentified_client_id]
+      client_id = params[:deidentified_client_id].to_i
+      client_scope = DeidentifiedClient.deidentified
+    else
+      raise 'unroutable, should not be reached'
+    end
+
+    @non_hmis_client = client_scope.visible_to(current_user).find(client_id)
   end
 
   private def set_assessment

--- a/app/controllers/non_hmis_assessments_controller.rb
+++ b/app/controllers/non_hmis_assessments_controller.rb
@@ -156,7 +156,17 @@ class NonHmisAssessmentsController < ApplicationController
   end
 
   private def set_assessment
-    @assessment = NonHmisAssessment.visible_by(current_user).find(params[:id].to_i)
+    found = @non_hmis_client.assessments.find(params[:id].to_i)
+    allowed = false
+    case action_name
+    when :show
+      allowed = found.editable_by?(current_user)
+    when :edit, :update, :destroy, :unlock
+      allowed = found.viewable_by?(current_user)
+    end
+    raise ActionController::RoutingError.new('Not Found') unless allowed
+
+    @assessment = found
   end
 
   private def set_neighborhoods

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -401,9 +401,14 @@ class Client < ApplicationRecord
 
   def remote_client_visible_to?(user)
     return true unless project_client.is_deidentified? || project_client.is_identified?
-    return true if NonHmisClient.visible_to(user).where(id: remote_id).exists?
 
-    false
+    [
+      DeidentifiedClient.deidentified,
+      IdentifiedClient.identified,
+      ImportedClient.all,
+    ].any? do |scope|
+      scope.visible_to(user).where(id: remote_id).exists?
+    end
   end
 
   # Link to the warehouse or other authoritative data source

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -50,6 +50,7 @@ class DeidentifiedClient < NonHmisClient
   end
 
   def editable_by?(user)
+    return true if user.can_manage_all_deidentified_clients?
     return true if user.can_manage_deidentified_clients?
     return true if pathways_enabled? && user.can_enter_deidentified_clients?
     return user.agency_id == agency_id if user.can_enter_deidentified_clients?

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -14,19 +14,8 @@ class DeidentifiedClient < NonHmisClient
   scope :visible_to, ->(user) do
     if user.can_edit_all_clients? || user.can_manage_all_deidentified_clients?
       all
-    elsif user.can_view_all_covid_pathways?
-      covid_ids = where(id: NonHmisAssessment.limitable_pathways.select(:non_hmis_client_id)).pluck(:id)
-      agency_associated_ids = where(
-        arel_table[:agency_id].eq(nil).
-        or(arel_table[:agency_id].eq(user.agency.id)),
-      ).pluck(:id)
-
-      where(id: covid_ids + agency_associated_ids)
     else
-      where(
-        arel_table[:agency_id].eq(nil).
-        or(arel_table[:agency_id].eq(user.agency.id)),
-      )
+      visible_through_user_agency(user)
     end
   end
 

--- a/app/models/identified_client.rb
+++ b/app/models/identified_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -14,19 +16,8 @@ class IdentifiedClient < NonHmisClient
   scope :visible_to, ->(user) do
     if user.can_edit_all_clients? || user.can_manage_all_identified_clients?
       all
-    elsif user.can_view_all_covid_pathways?
-      covid_ids = where(id: NonHmisAssessment.limitable_pathways.select(:non_hmis_client_id)).pluck(:id)
-      agency_associated_ids = where(
-        arel_table[:agency_id].eq(nil).
-        or(arel_table[:agency_id].eq(user.agency.id)),
-      ).pluck(:id)
-
-      where(id: covid_ids + agency_associated_ids)
     else
-      where(
-        arel_table[:agency_id].eq(nil).
-        or(arel_table[:agency_id].eq(user.agency.id)),
-      )
+      visible_through_user_agency(user)
     end
   end
 

--- a/app/models/identified_client.rb
+++ b/app/models/identified_client.rb
@@ -76,6 +76,7 @@ class IdentifiedClient < NonHmisClient
   end
 
   def editable_by?(user)
+    return true if user.can_manage_all_identified_clients?
     return true if user.can_manage_identified_clients?
     return true if pathways_enabled? && user.can_enter_identified_clients?
     return user.agency_id == agency_id if user.can_enter_identified_clients?

--- a/app/models/imported_client.rb
+++ b/app/models/imported_client.rb
@@ -59,6 +59,14 @@ class ImportedClient < NonHmisClient
     where(where)
   end
 
+  scope :visible_to, ->(user) do
+    if user.can_edit_all_clients? || user.can_manage_imported_clients?
+      all
+    elsif visible_through_user_agency(user)
+      visible_through_user_agency(user)
+    end
+  end
+
   def editable_by?(user)
     return true if user.can_manage_imported_clients?
 

--- a/app/models/imported_client.rb
+++ b/app/models/imported_client.rb
@@ -62,7 +62,7 @@ class ImportedClient < NonHmisClient
   scope :visible_to, ->(user) do
     if user.can_edit_all_clients? || user.can_manage_imported_clients?
       all
-    elsif visible_through_user_agency(user)
+    else
       visible_through_user_agency(user)
     end
   end

--- a/app/models/non_hmis_assessment.rb
+++ b/app/models/non_hmis_assessment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -27,14 +29,6 @@ class NonHmisAssessment < ActiveRecord::Base
 
   scope :limitable_pathways, -> do
     where(type: limited_assessment_types)
-  end
-
-  scope :visible_by, ->(user) do
-    where(non_hmis_client_id: NonHmisClient.visible_to(user).select(:id))
-  end
-
-  scope :editable_by, ->(user) do
-    where(agency_id: user.agency_id)
   end
 
   def self.to_class(name)

--- a/app/models/non_hmis_assessment.rb
+++ b/app/models/non_hmis_assessment.rb
@@ -134,11 +134,11 @@ class NonHmisAssessment < ActiveRecord::Base
   end
 
   def pathways_v3?
-    type.include?('PathwaysVersionThree')
+    type&.include?('PathwaysVersionThree')
   end
 
   def pathways_v4?
-    type.include?('PathwaysVersionFour')
+    type&.include?('PathwaysVersionFour')
   end
 
   def total_days_homeless_in_the_last_three_years

--- a/app/models/non_hmis_client.rb
+++ b/app/models/non_hmis_client.rb
@@ -31,10 +31,8 @@ class NonHmisClient < ApplicationRecord
     where(available: true)
   end
 
-  scope :visible_to, ->(user) do
-    if user.can_edit_all_clients?
-      all
-    elsif user.can_view_all_covid_pathways?
+  scope :visible_through_user_agency, ->(user) do
+    if user.can_view_all_covid_pathways?
       covid_ids = where(id: NonHmisAssessment.limitable_pathways.select(:non_hmis_client_id)).pluck(:id)
       agency_associated_ids = where(
         arel_table[:agency_id].eq(nil).

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ###
 # Copyright 2016 - 2025 Green River Data Analysis, LLC
 #
@@ -94,14 +96,14 @@ class Role < ApplicationRecord
       :can_manage_config,
       :can_create_overall_note,
       :can_delete_client_notes,
-      :can_enter_deidentified_clients,
+      :can_enter_deidentified_clients, # Allows entering/editing de-identified clients for the user's own agency.
       :can_manage_deidentified_clients,
-      :can_manage_all_deidentified_clients,
+      :can_manage_all_deidentified_clients, # Administrative permission: Allows managing de-identified clients across all agencies.
       :can_export_deidentified_clients,
       :can_add_cohorts_to_deidentified_clients,
-      :can_enter_identified_clients,
+      :can_enter_identified_clients, # Allows entering/editing identified clients for the user's own agency.
       :can_manage_identified_clients,
-      :can_manage_all_identified_clients,
+      :can_manage_all_identified_clients, # Administrative permission: Allows managing identified clients across all agencies.
       :can_export_identified_clients,
       :can_view_all_covid_pathways,
       :can_add_cohorts_to_identified_clients,

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -80,50 +80,6 @@
       "note": ""
     },
     {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 24,
-      "fingerprint": "15dafe767dd3ee8f4ad2d10f3e833ed4d4b3763f74ecea893a8d8e5a6e3504ad",
-      "check_name": "UnsafeReflection",
-      "message": "Unsafe reflection method `constantize` called on model attribute",
-      "file": "app/views/non_hmis_assessments/_index.haml",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
-      "code": "NonHmisClient.visible_to(current_user).find((params[:identified_client_id] or params[:deidentified_client_id]).to_i).assessment_type.constantize",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "NonHmisAssessmentsController",
-          "method": "index",
-          "line": 17,
-          "file": "app/controllers/non_hmis_assessments_controller.rb",
-          "rendered": {
-            "name": "non_hmis_assessments/index",
-            "file": "app/views/non_hmis_assessments/index.haml"
-          }
-        },
-        {
-          "type": "template",
-          "name": "non_hmis_assessments/index",
-          "line": 1,
-          "file": "app/views/non_hmis_assessments/index.haml",
-          "rendered": {
-            "name": "non_hmis_assessments/_index",
-            "file": "app/views/non_hmis_assessments/_index.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "non_hmis_assessments/_index"
-      },
-      "user_input": "NonHmisClient.visible_to(current_user).find((params[:identified_client_id] or params[:deidentified_client_id]).to_i)",
-      "confidence": "Medium",
-      "cwe_id": [
-        470
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "272bd9135442f395012a87ac47a02fe2dcaa8bf8f7db7b78b079036a4279e439",
@@ -407,6 +363,50 @@
       "note": ""
     },
     {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "766bfe92c30146079752b09d21f5626fdd45897124919f2dcb115f5785e5779f",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method `constantize` called on parameter value",
+      "file": "app/views/non_hmis_assessments/_index.haml",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "((nil or DeidentifiedClient.deidentified) or IdentifiedClient.identified).visible_to(current_user).find(((nil or params[:deidentified_client_id].to_i) or params[:identified_client_id].to_i)).assessment_type.constantize",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "NonHmisAssessmentsController",
+          "method": "index",
+          "line": 19,
+          "file": "app/controllers/non_hmis_assessments_controller.rb",
+          "rendered": {
+            "name": "non_hmis_assessments/index",
+            "file": "app/views/non_hmis_assessments/index.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "non_hmis_assessments/index",
+          "line": 1,
+          "file": "app/views/non_hmis_assessments/index.haml",
+          "rendered": {
+            "name": "non_hmis_assessments/_index",
+            "file": "app/views/non_hmis_assessments/_index.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "non_hmis_assessments/_index"
+      },
+      "user_input": "params[:identified_client_id]",
+      "confidence": "Medium",
+      "cwe_id": [
+        470
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "85e335c4575b12b61263ca6d933cb810fe5f86ad44c5f53e83e8558af7897a58",
@@ -428,6 +428,50 @@
         77
       ],
       "note": "We're just injecting the git revision."
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "aa40ebbd05a2cdc706d57a2f8e6b85f802a97a5319aa8417ca850ebe851e84fd",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/non_hmis_assessments/_form.haml",
+      "line": 37,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"#{((nil or DeidentifiedClient.deidentified) or IdentifiedClient.identified).visible_to(current_user).find(((nil or params[:deidentified_client_id].to_i) or params[:identified_client_id].to_i)).type.tableize}/#{build_assessment.model_name.element}\", { :client_form => f, :assessment_form => f, :disabled => disabled, :limited => build_assessment.hide_confidential?(current_user) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "NonHmisAssessmentsController",
+          "method": "new",
+          "line": 23,
+          "file": "app/controllers/non_hmis_assessments_controller.rb",
+          "rendered": {
+            "name": "non_hmis_assessments/new",
+            "file": "app/views/non_hmis_assessments/new.haml"
+          }
+        },
+        {
+          "type": "template",
+          "name": "non_hmis_assessments/new",
+          "line": 1,
+          "file": "app/views/non_hmis_assessments/new.haml",
+          "rendered": {
+            "name": "non_hmis_assessments/_form",
+            "file": "app/views/non_hmis_assessments/_form.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "non_hmis_assessments/_form"
+      },
+      "user_input": "params[:identified_client_id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ],
+      "note": ""
     },
     {
       "warning_type": "SQL Injection",
@@ -549,7 +593,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on model attribute",
       "file": "app/models/deidentified_client.rb",
-      "line": 83,
+      "line": 74,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Config.get(:deidentified_client_assessment).constantize",
       "render_path": null,
@@ -695,7 +739,7 @@
       "check_name": "UnsafeReflection",
       "message": "Unsafe reflection method `constantize` called on model attribute",
       "file": "app/models/identified_client.rb",
-      "line": 122,
+      "line": 113,
       "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
       "code": "Config.get(:identified_client_assessment).constantize",
       "render_path": null,

--- a/spec/factories/deidentified_clients.rb
+++ b/spec/factories/deidentified_clients.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     client_identifier { Faker::Number.number(digits: 4) }
     first_name { "Anonymous - #{client_identifier}" }
     last_name  { "Anonymous - #{client_identifier}" }
+    identified { false }
   end
 end

--- a/spec/factories/deidentified_clients.rb
+++ b/spec/factories/deidentified_clients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :deidentified_client do
     client_identifier { Faker::Number.number(digits: 4) }

--- a/spec/factories/imported_clients.rb
+++ b/spec/factories/imported_clients.rb
@@ -6,11 +6,5 @@ FactoryBot.define do
     sequence(:last_name) { |n| "Client#{n}" }
     sequence(:email) { |n| "imported_client_#{n}@example.com" }
     association :agency, optional: true # Allow agency to be nil or set
-
-    # Traits for specific scenarios if needed, e.g., for warehouse_assessment? logic
-    # trait :with_warehouse_details do
-    #   warehouse_client_id { SecureRandom.uuid }
-    #   # further associations/attributes for warehouse_assessment? to be true
-    # end
   end
 end

--- a/spec/factories/imported_clients.rb
+++ b/spec/factories/imported_clients.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :imported_client do
+    first_name { 'Imported' }
+    sequence(:last_name) { |n| "Client#{n}" }
+    sequence(:email) { |n| "imported_client_#{n}@example.com" }
+    association :agency, optional: true # Allow agency to be nil or set
+
+    # Traits for specific scenarios if needed, e.g., for warehouse_assessment? logic
+    # trait :with_warehouse_details do
+    #   warehouse_client_id { SecureRandom.uuid }
+    #   # further associations/attributes for warehouse_assessment? to be true
+    # end
+  end
+end

--- a/spec/factories/non_hmis_assessments.rb
+++ b/spec/factories/non_hmis_assessments.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :non_hmis_assessment do
+    association :non_hmis_client
+    association :agency
+    entry_date { Date.today }
+    # Add other default attributes as necessary, e.g., type
+    # For testing 'limitable_pathways', we might need specific types.
+    # NonHmisAssessment.limited_assessment_types returns:
+    # ["DeidentifiedCovidPathwaysAssessment", "IdentifiedCovidPathwaysAssessment",
+    #  "DeidentifiedPathwaysVersionThree", "IdentifiedPathwaysVersionThree",
+    #  "DeidentifiedPathwaysVersionFour", "IdentifiedPathwaysVersionFour"]
+    # Let's default to one of these for now, or allow it to be passed.
+    type { 'DeidentifiedCovidPathwaysAssessment' }
+
+    trait :limitable_pathway do
+      type { NonHmisAssessment.limited_assessment_types.sample }
+    end
+
+    trait :non_limitable_pathway do
+      type { 'SomeOtherAssessmentType' } # A placeholder for a non-limitable type
+    end
+  end
+end

--- a/spec/factories/non_hmis_assessments.rb
+++ b/spec/factories/non_hmis_assessments.rb
@@ -5,13 +5,6 @@ FactoryBot.define do
     association :non_hmis_client
     association :agency
     entry_date { Date.today }
-    # Add other default attributes as necessary, e.g., type
-    # For testing 'limitable_pathways', we might need specific types.
-    # NonHmisAssessment.limited_assessment_types returns:
-    # ["DeidentifiedCovidPathwaysAssessment", "IdentifiedCovidPathwaysAssessment",
-    #  "DeidentifiedPathwaysVersionThree", "IdentifiedPathwaysVersionThree",
-    #  "DeidentifiedPathwaysVersionFour", "IdentifiedPathwaysVersionFour"]
-    # Let's default to one of these for now, or allow it to be passed.
     type { 'DeidentifiedCovidPathwaysAssessment' }
 
     trait :limitable_pathway do

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -618,4 +618,199 @@ RSpec.describe Client, type: :model do
       end
     end
   end
+
+  describe 'remote_client_visible_to?' do
+    let!(:user_agency) { create(:agency, name: 'User Test Agency') }
+    let!(:other_agency) { create(:agency, name: 'Other Test Agency') }
+    let!(:deidentified_data_source) { create(:data_source, :deidentified) } # Defined once
+
+    let!(:admin_role) { create(:role, name: 'remote_client_test_admin_editor', can_edit_all_clients: true) }
+    let!(:admin_user) { create(:user, agency: user_agency, roles: [admin_role]) }
+
+    let!(:basic_role) { create(:role, name: 'remote_client_test_basic_user') } # No special global perms
+    let!(:basic_user_in_user_agency) { create(:user, agency: user_agency, roles: [basic_role]) }
+    let!(:basic_user_in_other_agency) { create(:user, agency: other_agency, roles: [basic_role]) }
+
+    let!(:deid_manager_role) { create(:role, name: 'remote_client_test_deid_manager', can_manage_all_deidentified_clients: true) }
+    let!(:deid_viewer) { create(:user, agency: user_agency, roles: [deid_manager_role]) }
+
+    # ASSUMPTION: Role model has can_manage_all_identified_clients attribute
+    let!(:id_manager_role) { create(:role, name: 'remote_client_test_id_manager', can_manage_all_identified_clients: true) }
+    let!(:identified_viewer) { create(:user, agency: user_agency, roles: [id_manager_role]) }
+
+    # ASSUMPTION: Role model has can_manage_imported_clients attribute
+    let!(:imp_manager_role) { create(:role, name: 'remote_client_test_imp_manager', can_manage_imported_clients: true) }
+    let!(:imported_viewer) { create(:user, agency: user_agency, roles: [imp_manager_role]) }
+
+    let!(:client_under_test) do
+      client = create(:client)
+      # Ensure project_client exists and has the correct data_source_id for NonHmis related records
+      create(:project_client, client_id: client.id, data_source_id: deidentified_data_source.id)
+      client
+    end
+
+    # Helper to link client_under_test's project_client to a specific NonHmisClient record
+    # This NonHmisClient record's `identified` boolean will drive ProjectClient#is_identified?/is_deidentified?
+    # and its ID will be used as `remote_id` in the visibility check loop.
+    def link_project_client_to_remote_record(client_obj, remote_record_instance)
+      pc = client_obj.project_client
+      # Ensure data_source_id is correct for NonHmisClient types, matching what project_client was created with.
+      # This assumes DeidentifiedClient, IdentifiedClient, ImportedClient all use this deidentified_data_source
+      expected_non_hmis_ds_id = deidentified_data_source.id
+
+      unless pc.data_source_id == expected_non_hmis_ds_id
+        # Fail fast if there's a mismatch, as it indicates a setup problem for these tests.
+        raise "ProjectClient data_source_id mismatch: PC has #{pc.data_source_id}, expected NonHmis DS ID is #{expected_non_hmis_ds_id}"
+      end
+
+      pc.update!(id_in_data_source: remote_record_instance.id)
+      client_obj.reload # Crucial for client.remote_id and project_client states
+    end
+
+    context 'when project_client is not effectively linked to a NonHmisClient (making is_deidentified? and is_identified? both false)' do
+      before do
+        # Ensure project_client.id_in_data_source points to nothing, making actual_remote_record nil
+        # (assuming ProjectClient#is_identified?/is_deidentified? rely on actual_remote_record)
+        client_under_test.project_client.update!(id_in_data_source: -999) # Non-existent ID
+        client_under_test.reload
+      end
+
+      it 'returns true (due to the `unless` condition in the method)' do
+        # This tests the first return path: `return true unless project_client.is_deidentified? || project_client.is_identified?`
+        expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+      end
+    end
+
+    context 'when project_client is linked to an actual NonHmisClient record' do
+      # These contexts test the main loop logic where is_deidentified? OR is_identified? is true.
+
+      context 'and linked to a DeidentifiedClient (record.identified == false)' do
+        let!(:deid_visible_to_basic) { create(:deidentified_client, agency: user_agency, identified: false) }
+        let!(:deid_invisible_to_basic) { create(:deidentified_client, agency: other_agency, identified: false) }
+        let!(:deid_for_admin) { create(:deidentified_client, agency: other_agency, identified: false) }
+        let!(:deid_for_deid_viewer) { create(:deidentified_client, agency: other_agency, identified: false) }
+
+        it 'returns true if linked DeidentifiedClient is visible to basic_user_in_user_agency' do
+          link_project_client_to_remote_record(client_under_test, deid_visible_to_basic)
+          expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+        end
+
+        it 'returns false if linked DeidentifiedClient is not visible to basic_user_in_user_agency (and no other types match for this ID)' do
+          link_project_client_to_remote_record(client_under_test, deid_invisible_to_basic)
+          # Ensure no other client types with this ID could grant visibility
+          IdentifiedClient.where(id: deid_invisible_to_basic.id).destroy_all
+          ImportedClient.where(id: deid_invisible_to_basic.id).destroy_all
+          expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be false
+        end
+
+        it 'returns true if linked DeidentifiedClient is visible to admin_user' do
+          link_project_client_to_remote_record(client_under_test, deid_for_admin)
+          expect(client_under_test.remote_client_visible_to?(admin_user)).to be true
+        end
+
+        it 'returns true if linked DeidentifiedClient is visible to deid_viewer' do
+          link_project_client_to_remote_record(client_under_test, deid_for_deid_viewer)
+          expect(client_under_test.remote_client_visible_to?(deid_viewer)).to be true
+        end
+      end
+
+      context 'and linked to an IdentifiedClient (record.identified == true)' do
+        let!(:id_visible_to_basic) { create(:identified_client, agency: user_agency, identified: true) }
+        let!(:id_invisible_to_basic) { create(:identified_client, agency: other_agency, identified: true) }
+        let!(:id_for_admin) { create(:identified_client, agency: other_agency, identified: true) }
+        let!(:id_for_id_viewer) { create(:identified_client, agency: other_agency, identified: true) }
+
+        it 'returns true if linked IdentifiedClient is visible to basic_user_in_user_agency' do
+          link_project_client_to_remote_record(client_under_test, id_visible_to_basic)
+          expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+        end
+
+        it 'returns false if linked IdentifiedClient is not visible to basic_user_in_user_agency (and no other types match)' do
+          link_project_client_to_remote_record(client_under_test, id_invisible_to_basic)
+          DeidentifiedClient.where(id: id_invisible_to_basic.id).destroy_all
+          ImportedClient.where(id: id_invisible_to_basic.id).destroy_all
+          expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be false
+        end
+
+        it 'returns true if linked IdentifiedClient is visible to admin_user' do
+          link_project_client_to_remote_record(client_under_test, id_for_admin)
+          expect(client_under_test.remote_client_visible_to?(admin_user)).to be true
+        end
+
+        it 'returns true if linked IdentifiedClient is visible to identified_viewer' do
+          link_project_client_to_remote_record(client_under_test, id_for_id_viewer)
+          expect(client_under_test.remote_client_visible_to?(identified_viewer)).to be true
+        end
+      end
+
+      context 'and linked to an ImportedClient' do
+        # The ImportedClient.all scope is used, so its own `identified` status does not affect this specific scope's filtering.
+        # However, its `identified` status DOES affect ProjectClient#is_identified?/is_deidentified?,
+        # determining if we enter the loop.
+
+        context 'when the ImportedClient record has identified: false (making ProjectClient deidentified)' do
+          let!(:imp_deid_visible_to_basic) { create(:imported_client, agency: user_agency, identified: false) }
+          let!(:imp_deid_invisible_to_basic) { create(:imported_client, agency: other_agency, identified: false) }
+
+          it 'returns true if linked (deidentified) ImportedClient is visible to basic_user_in_user_agency' do
+            link_project_client_to_remote_record(client_under_test, imp_deid_visible_to_basic)
+            expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+          end
+
+          it 'returns false if linked (deidentified) ImportedClient is not visible (and others do not match)' do
+            link_project_client_to_remote_record(client_under_test, imp_deid_invisible_to_basic)
+            DeidentifiedClient.where(id: imp_deid_invisible_to_basic.id).destroy_all
+            IdentifiedClient.where(id: imp_deid_invisible_to_basic.id).destroy_all
+            expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be false
+          end
+        end
+
+        context 'when the ImportedClient record has identified: true (making ProjectClient identified)' do
+          let!(:imp_id_visible_to_basic) { create(:imported_client, agency: user_agency, identified: true) }
+          let!(:imp_id_invisible_to_basic) { create(:imported_client, agency: other_agency, identified: true) }
+
+          it 'returns true if linked (identified) ImportedClient is visible to basic_user_in_user_agency' do
+            link_project_client_to_remote_record(client_under_test, imp_id_visible_to_basic)
+            expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+          end
+
+          it 'returns false if linked (identified) ImportedClient is not visible (and others do not match)' do
+            link_project_client_to_remote_record(client_under_test, imp_id_invisible_to_basic)
+            DeidentifiedClient.where(id: imp_id_invisible_to_basic.id).destroy_all
+            IdentifiedClient.where(id: imp_id_invisible_to_basic.id).destroy_all
+            expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be false
+          end
+        end
+
+        it 'returns true if linked ImportedClient is visible to admin_user' do
+            imp_for_admin = create(:imported_client, agency: other_agency, identified: true) # identified status for initial check
+            link_project_client_to_remote_record(client_under_test, imp_for_admin)
+            expect(client_under_test.remote_client_visible_to?(admin_user)).to be true
+        end
+
+        it 'returns true if linked ImportedClient is visible to imported_viewer' do
+            imp_for_viewer = create(:imported_client, agency: other_agency, identified: false) # identified status for initial check
+            link_project_client_to_remote_record(client_under_test, imp_for_viewer)
+            expect(client_under_test.remote_client_visible_to?(imported_viewer)).to be true
+        end
+      end
+
+      # Test the OR logic of the .any? block
+      it 'returns true if remote_id matches a visible DeidentifiedClient, even if an IdentifiedClient with same ID would not be visible' do
+        # Setup: PC linked to a DeidentifiedClient that IS visible
+        visible_deid = create(:deidentified_client, agency: user_agency, identified: false)
+        link_project_client_to_remote_record(client_under_test, visible_deid)
+
+        expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+      end
+
+      it 'returns true if remote_id matches a visible IdentifiedClient, after a DeidentifiedClient with same ID was not visible' do
+        # Setup: PC linked to an IdentifiedClient that IS visible
+        visible_id = create(:identified_client, agency: user_agency, identified: true)
+        link_project_client_to_remote_record(client_under_test, visible_id)
+
+        expect(client_under_test.remote_client_visible_to?(basic_user_in_user_agency)).to be true
+      end
+    end
+  end
 end

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -634,11 +634,9 @@ RSpec.describe Client, type: :model do
     let!(:deid_manager_role) { create(:role, name: 'remote_client_test_deid_manager', can_manage_all_deidentified_clients: true) }
     let!(:deid_viewer) { create(:user, agency: user_agency, roles: [deid_manager_role]) }
 
-    # ASSUMPTION: Role model has can_manage_all_identified_clients attribute
     let!(:id_manager_role) { create(:role, name: 'remote_client_test_id_manager', can_manage_all_identified_clients: true) }
     let!(:identified_viewer) { create(:user, agency: user_agency, roles: [id_manager_role]) }
 
-    # ASSUMPTION: Role model has can_manage_imported_clients attribute
     let!(:imp_manager_role) { create(:role, name: 'remote_client_test_imp_manager', can_manage_imported_clients: true) }
     let!(:imported_viewer) { create(:user, agency: user_agency, roles: [imp_manager_role]) }
 

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -783,15 +783,15 @@ RSpec.describe Client, type: :model do
         end
 
         it 'returns true if linked ImportedClient is visible to admin_user' do
-            imp_for_admin = create(:imported_client, agency: other_agency, identified: true) # identified status for initial check
-            link_project_client_to_remote_record(client_under_test, imp_for_admin)
-            expect(client_under_test.remote_client_visible_to?(admin_user)).to be true
+          imp_for_admin = create(:imported_client, agency: other_agency, identified: true) # identified status for initial check
+          link_project_client_to_remote_record(client_under_test, imp_for_admin)
+          expect(client_under_test.remote_client_visible_to?(admin_user)).to be true
         end
 
         it 'returns true if linked ImportedClient is visible to imported_viewer' do
-            imp_for_viewer = create(:imported_client, agency: other_agency, identified: false) # identified status for initial check
-            link_project_client_to_remote_record(client_under_test, imp_for_viewer)
-            expect(client_under_test.remote_client_visible_to?(imported_viewer)).to be true
+          imp_for_viewer = create(:imported_client, agency: other_agency, identified: false) # identified status for initial check
+          link_project_client_to_remote_record(client_under_test, imp_for_viewer)
+          expect(client_under_test.remote_client_visible_to?(imported_viewer)).to be true
         end
       end
 

--- a/spec/models/deidentified_client_spec.rb
+++ b/spec/models/deidentified_client_spec.rb
@@ -21,16 +21,6 @@ RSpec.describe DeidentifiedClient, type: :model do
       user
     end
 
-    let!(:user_with_covid_pathways_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'covid_pathway_viewer',
-                           can_edit_all_clients: false,
-                           can_manage_all_deidentified_clients: false,
-                           can_view_all_covid_pathways: true)
-      user.roles << role
-      user
-    end
-
     let!(:user_with_basic_role) do
       user = create(:user, agency: user_agency)
       role = create(:role, name: 'basic_user',
@@ -45,59 +35,28 @@ RSpec.describe DeidentifiedClient, type: :model do
     let!(:client_other_agency) { create(:deidentified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
     let!(:client_nil_agency) { create(:deidentified_client, agency: nil, first_name: 'ClientNilAgency') }
 
-    # For testing visible_through_user_agency indirectly
-    let!(:client_covid_pathway_other_agency) do
-      client = create(:deidentified_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
-      client
-    end
-
-    let!(:client_covid_pathway_user_agency) do
-      client = create(:deidentified_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
-      client
-    end
-
     context 'when user has a role with can_edit_all_clients?' do
       it 'returns all deidentified clients' do
         scope_results = described_class.visible_to(user_with_edit_all_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
     context 'when user has a role with can_manage_all_deidentified_clients?' do
       it 'returns all deidentified clients' do
         scope_results = described_class.visible_to(user_with_manage_deidentified_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
-    context 'when user has basic role and can_view_all_covid_pathways?' do
-      # This user can see their own agency's clients, nil agency clients,
-      # and any client with a covid pathway assessment.
-      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
-        scope_results = described_class.visible_to(user_with_covid_pathways_role)
-        expect(scope_results).to contain_exactly(
-          client_user_agency,
-          client_nil_agency,
-          client_covid_pathway_user_agency, # Via user_agency AND covid pathway
-          client_covid_pathway_other_agency, # Via covid pathway only
-        )
-        expect(scope_results).not_to include(client_other_agency) # No covid pathway, other agency
-      end
-    end
-
-    context 'when user has basic role and cannot_view_all_covid_pathways?' do
-      # This user can only see their own agency's clients and nil agency clients.
-      it 'returns clients from user agency and nil agency only' do
+    context 'when user has a basic role' do
+      it 'returns clients from their agency and nil agency only' do
         scope_results = described_class.visible_to(user_with_basic_role)
         expect(scope_results).to contain_exactly(
           client_user_agency,
           client_nil_agency,
-          client_covid_pathway_user_agency, # Via user_agency (covid pathway is irrelevant here for visibility scope)
         )
         expect(scope_results).not_to include(client_other_agency)
-        expect(scope_results).not_to include(client_covid_pathway_other_agency)
       end
     end
   end

--- a/spec/models/deidentified_client_spec.rb
+++ b/spec/models/deidentified_client_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeidentifiedClient, type: :model do
+  describe '.visible_to' do
+    let!(:user_agency) { create(:agency, name: 'User Agency') }
+    let!(:other_agency) { create(:agency, name: 'Other Agency') }
+
+    let!(:user_with_edit_all_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'editor_of_all', can_edit_all_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_manage_deidentified_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'deidentified_manager', can_edit_all_clients: false, can_manage_all_deidentified_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_covid_pathways_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'covid_pathway_viewer',
+                           can_edit_all_clients: false,
+                           can_manage_all_deidentified_clients: false,
+                           can_view_all_covid_pathways: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_basic_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'basic_user',
+                           can_edit_all_clients: false,
+                           can_manage_all_deidentified_clients: false,
+                           can_view_all_covid_pathways: false)
+      user.roles << role
+      user
+    end
+
+    let!(:client_user_agency) { create(:deidentified_client, agency: user_agency, first_name: 'ClientUserAgency') }
+    let!(:client_other_agency) { create(:deidentified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
+    let!(:client_nil_agency) { create(:deidentified_client, agency: nil, first_name: 'ClientNilAgency') }
+
+    # For testing visible_through_user_agency indirectly
+    let!(:client_covid_pathway_other_agency) do
+      client = create(:deidentified_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
+      client
+    end
+
+    let!(:client_covid_pathway_user_agency) do
+      client = create(:deidentified_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
+      client
+    end
+
+    context 'when user has a role with can_edit_all_clients?' do
+      it 'returns all deidentified clients' do
+        scope_results = described_class.visible_to(user_with_edit_all_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has a role with can_manage_all_deidentified_clients?' do
+      it 'returns all deidentified clients' do
+        scope_results = described_class.visible_to(user_with_manage_deidentified_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has basic role and can_view_all_covid_pathways?' do
+      # This user can see their own agency's clients, nil agency clients,
+      # and any client with a covid pathway assessment.
+      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
+        scope_results = described_class.visible_to(user_with_covid_pathways_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency, # Via user_agency AND covid pathway
+          client_covid_pathway_other_agency, # Via covid pathway only
+        )
+        expect(scope_results).not_to include(client_other_agency) # No covid pathway, other agency
+      end
+    end
+
+    context 'when user has basic role and cannot_view_all_covid_pathways?' do
+      # This user can only see their own agency's clients and nil agency clients.
+      it 'returns clients from user agency and nil agency only' do
+        scope_results = described_class.visible_to(user_with_basic_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency, # Via user_agency (covid pathway is irrelevant here for visibility scope)
+        )
+        expect(scope_results).not_to include(client_other_agency)
+        expect(scope_results).not_to include(client_covid_pathway_other_agency)
+      end
+    end
+  end
+end

--- a/spec/models/deidentified_client_spec.rb
+++ b/spec/models/deidentified_client_spec.rb
@@ -3,61 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe DeidentifiedClient, type: :model do
-  describe '.visible_to' do
-    let!(:user_agency) { create(:agency, name: 'User Agency') }
-    let!(:other_agency) { create(:agency, name: 'Other Agency') }
-
-    let!(:user_with_edit_all_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'editor_of_all', can_edit_all_clients: true)
-      user.roles << role
-      user
-    end
-
-    let!(:user_with_manage_deidentified_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'deidentified_manager', can_edit_all_clients: false, can_manage_all_deidentified_clients: true)
-      user.roles << role
-      user
-    end
-
-    let!(:user_with_basic_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'basic_user',
-                           can_edit_all_clients: false,
-                           can_manage_all_deidentified_clients: false,
-                           can_view_all_covid_pathways: false)
-      user.roles << role
-      user
-    end
-
-    let!(:client_user_agency) { create(:deidentified_client, agency: user_agency, first_name: 'ClientUserAgency') }
-    let!(:client_other_agency) { create(:deidentified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
-    let!(:client_nil_agency) { create(:deidentified_client, agency: nil, first_name: 'ClientNilAgency') }
-
-    context 'when user has a role with can_edit_all_clients?' do
-      it 'returns all deidentified clients' do
-        scope_results = described_class.visible_to(user_with_edit_all_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
-      end
-    end
-
-    context 'when user has a role with can_manage_all_deidentified_clients?' do
-      it 'returns all deidentified clients' do
-        scope_results = described_class.visible_to(user_with_manage_deidentified_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
-      end
-    end
-
-    context 'when user has a basic role' do
-      it 'returns clients from their agency and nil agency only' do
-        scope_results = described_class.visible_to(user_with_basic_role)
-        expect(scope_results).to contain_exactly(
-          client_user_agency,
-          client_nil_agency,
-        )
-        expect(scope_results).not_to include(client_other_agency)
-      end
-    end
-  end
+  it_behaves_like 'client core visibility and editability',
+                  :deidentified_client,
+                  :can_manage_all_deidentified_clients,
+                  :can_manage_deidentified_clients,
+                  :can_enter_deidentified_clients
 end

--- a/spec/models/identified_client_spec.rb
+++ b/spec/models/identified_client_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IdentifiedClient, type: :model do
+  describe '.visible_to' do
+    let!(:user_agency) { create(:agency, name: 'User Agency') }
+    let!(:other_agency) { create(:agency, name: 'Other Agency') }
+
+    let!(:user_with_edit_all_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'editor_of_all', can_edit_all_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_manage_identified_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'identified_manager', can_edit_all_clients: false, can_manage_all_identified_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_covid_pathways_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'covid_pathway_viewer',
+                           can_edit_all_clients: false,
+                           can_manage_all_identified_clients: false,
+                           can_view_all_covid_pathways: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_basic_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'basic_user',
+                           can_edit_all_clients: false,
+                           can_manage_all_identified_clients: false,
+                           can_view_all_covid_pathways: false)
+      user.roles << role
+      user
+    end
+
+    let!(:client_user_agency) { create(:identified_client, agency: user_agency, first_name: 'ClientUserAgency') }
+    let!(:client_other_agency) { create(:identified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
+    let!(:client_nil_agency) { create(:identified_client, agency: nil, first_name: 'ClientNilAgency') }
+
+    # For testing visible_through_user_agency indirectly
+    let!(:client_covid_pathway_other_agency) do
+      client = create(:identified_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
+      client
+    end
+
+    let!(:client_covid_pathway_user_agency) do
+      client = create(:identified_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
+      client
+    end
+
+    context 'when user has a role with can_edit_all_clients?' do
+      it 'returns all identified clients' do
+        scope_results = described_class.visible_to(user_with_edit_all_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has a role with can_manage_all_identified_clients?' do
+      it 'returns all identified clients' do
+        scope_results = described_class.visible_to(user_with_manage_identified_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has basic role and can_view_all_covid_pathways?' do
+      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
+        scope_results = described_class.visible_to(user_with_covid_pathways_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency,
+          client_covid_pathway_other_agency,
+        )
+        expect(scope_results).not_to include(client_other_agency)
+      end
+    end
+
+    context 'when user has basic role and cannot_view_all_covid_pathways?' do
+      it 'returns clients from user agency and nil agency only' do
+        scope_results = described_class.visible_to(user_with_basic_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency,
+        )
+        expect(scope_results).not_to include(client_other_agency)
+        expect(scope_results).not_to include(client_covid_pathway_other_agency)
+      end
+    end
+  end
+end

--- a/spec/models/identified_client_spec.rb
+++ b/spec/models/identified_client_spec.rb
@@ -3,61 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe IdentifiedClient, type: :model do
-  describe '.visible_to' do
-    let!(:user_agency) { create(:agency, name: 'User Agency') }
-    let!(:other_agency) { create(:agency, name: 'Other Agency') }
-
-    let!(:user_with_edit_all_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'editor_of_all', can_edit_all_clients: true)
-      user.roles << role
-      user
-    end
-
-    let!(:user_with_manage_identified_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'identified_manager', can_edit_all_clients: false, can_manage_all_identified_clients: true)
-      user.roles << role
-      user
-    end
-
-    let!(:user_with_basic_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'basic_user',
-                           can_edit_all_clients: false,
-                           can_manage_all_identified_clients: false,
-                           can_view_all_covid_pathways: false)
-      user.roles << role
-      user
-    end
-
-    let!(:client_user_agency) { create(:identified_client, agency: user_agency, first_name: 'ClientUserAgency') }
-    let!(:client_other_agency) { create(:identified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
-    let!(:client_nil_agency) { create(:identified_client, agency: nil, first_name: 'ClientNilAgency') }
-
-    context 'when user has a role with can_edit_all_clients?' do
-      it 'returns all identified clients' do
-        scope_results = described_class.visible_to(user_with_edit_all_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
-      end
-    end
-
-    context 'when user has a role with can_manage_all_identified_clients?' do
-      it 'returns all identified clients' do
-        scope_results = described_class.visible_to(user_with_manage_identified_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
-      end
-    end
-
-    context 'when user has a basic role' do
-      it 'returns clients from their agency and nil agency only' do
-        scope_results = described_class.visible_to(user_with_basic_role)
-        expect(scope_results).to contain_exactly(
-          client_user_agency,
-          client_nil_agency,
-        )
-        expect(scope_results).not_to include(client_other_agency)
-      end
-    end
-  end
+  it_behaves_like 'client core visibility and editability',
+                  :identified_client,
+                  :can_manage_all_identified_clients,
+                  :can_manage_identified_clients,
+                  :can_enter_identified_clients
 end

--- a/spec/models/identified_client_spec.rb
+++ b/spec/models/identified_client_spec.rb
@@ -21,16 +21,6 @@ RSpec.describe IdentifiedClient, type: :model do
       user
     end
 
-    let!(:user_with_covid_pathways_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'covid_pathway_viewer',
-                           can_edit_all_clients: false,
-                           can_manage_all_identified_clients: false,
-                           can_view_all_covid_pathways: true)
-      user.roles << role
-      user
-    end
-
     let!(:user_with_basic_role) do
       user = create(:user, agency: user_agency)
       role = create(:role, name: 'basic_user',
@@ -45,56 +35,28 @@ RSpec.describe IdentifiedClient, type: :model do
     let!(:client_other_agency) { create(:identified_client, agency: other_agency, first_name: 'ClientOtherAgency') }
     let!(:client_nil_agency) { create(:identified_client, agency: nil, first_name: 'ClientNilAgency') }
 
-    # For testing visible_through_user_agency indirectly
-    let!(:client_covid_pathway_other_agency) do
-      client = create(:identified_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
-      client
-    end
-
-    let!(:client_covid_pathway_user_agency) do
-      client = create(:identified_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
-      client
-    end
-
     context 'when user has a role with can_edit_all_clients?' do
       it 'returns all identified clients' do
         scope_results = described_class.visible_to(user_with_edit_all_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
     context 'when user has a role with can_manage_all_identified_clients?' do
       it 'returns all identified clients' do
         scope_results = described_class.visible_to(user_with_manage_identified_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
-    context 'when user has basic role and can_view_all_covid_pathways?' do
-      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
-        scope_results = described_class.visible_to(user_with_covid_pathways_role)
-        expect(scope_results).to contain_exactly(
-          client_user_agency,
-          client_nil_agency,
-          client_covid_pathway_user_agency,
-          client_covid_pathway_other_agency,
-        )
-        expect(scope_results).not_to include(client_other_agency)
-      end
-    end
-
-    context 'when user has basic role and cannot_view_all_covid_pathways?' do
-      it 'returns clients from user agency and nil agency only' do
+    context 'when user has a basic role' do
+      it 'returns clients from their agency and nil agency only' do
         scope_results = described_class.visible_to(user_with_basic_role)
         expect(scope_results).to contain_exactly(
           client_user_agency,
           client_nil_agency,
-          client_covid_pathway_user_agency,
         )
         expect(scope_results).not_to include(client_other_agency)
-        expect(scope_results).not_to include(client_covid_pathway_other_agency)
       end
     end
   end

--- a/spec/models/imported_client_spec.rb
+++ b/spec/models/imported_client_spec.rb
@@ -22,16 +22,6 @@ RSpec.describe ImportedClient, type: :model do
       user
     end
 
-    let!(:user_with_covid_pathways_role) do
-      user = create(:user, agency: user_agency)
-      role = create(:role, name: 'covid_pathway_viewer',
-                           can_edit_all_clients: false,
-                           can_manage_imported_clients: false,
-                           can_view_all_covid_pathways: true)
-      user.roles << role
-      user
-    end
-
     let!(:user_with_basic_role) do
       user = create(:user, agency: user_agency)
       role = create(:role, name: 'basic_user',
@@ -46,56 +36,28 @@ RSpec.describe ImportedClient, type: :model do
     let!(:client_other_agency) { create(:imported_client, agency: other_agency, first_name: 'ClientOtherAgency') }
     let!(:client_nil_agency) { create(:imported_client, agency: nil, first_name: 'ClientNilAgency') }
 
-    # For testing visible_through_user_agency indirectly
-    let!(:client_covid_pathway_other_agency) do
-      client = create(:imported_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
-      client
-    end
-
-    let!(:client_covid_pathway_user_agency) do
-      client = create(:imported_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
-      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
-      client
-    end
-
     context 'when user has a role with can_edit_all_clients?' do
       it 'returns all imported clients' do
         scope_results = described_class.visible_to(user_with_edit_all_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
     context 'when user has a role with can_manage_imported_clients?' do
       it 'returns all imported clients' do
         scope_results = described_class.visible_to(user_with_manage_imported_role)
-        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency)
       end
     end
 
-    context 'when user has basic role and can_view_all_covid_pathways?' do
-      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
-        scope_results = described_class.visible_to(user_with_covid_pathways_role)
-        expect(scope_results).to contain_exactly(
-          client_user_agency,
-          client_nil_agency,
-          client_covid_pathway_user_agency,
-          client_covid_pathway_other_agency,
-        )
-        expect(scope_results).not_to include(client_other_agency)
-      end
-    end
-
-    context 'when user has basic role and cannot_view_all_covid_pathways?' do
-      it 'returns clients from user agency and nil agency only' do
+    context 'when user has a basic role' do
+      it 'returns clients from their agency and nil agency only' do
         scope_results = described_class.visible_to(user_with_basic_role)
         expect(scope_results).to contain_exactly(
           client_user_agency,
           client_nil_agency,
-          client_covid_pathway_user_agency,
         )
         expect(scope_results).not_to include(client_other_agency)
-        expect(scope_results).not_to include(client_covid_pathway_other_agency)
       end
     end
   end

--- a/spec/models/imported_client_spec.rb
+++ b/spec/models/imported_client_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportedClient, type: :model do
+  describe '.visible_to' do
+    let!(:user_agency) { create(:agency, name: 'User Agency') }
+    let!(:other_agency) { create(:agency, name: 'Other Agency') }
+
+    let!(:user_with_edit_all_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'editor_of_all', can_edit_all_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_manage_imported_role) do
+      user = create(:user, agency: user_agency)
+      # Note: can_manage_imported_clients is the specific permission for ImportedClient
+      role = create(:role, name: 'imported_manager', can_edit_all_clients: false, can_manage_imported_clients: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_covid_pathways_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'covid_pathway_viewer',
+                           can_edit_all_clients: false,
+                           can_manage_imported_clients: false,
+                           can_view_all_covid_pathways: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_with_basic_role) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'basic_user',
+                           can_edit_all_clients: false,
+                           can_manage_imported_clients: false,
+                           can_view_all_covid_pathways: false)
+      user.roles << role
+      user
+    end
+
+    let!(:client_user_agency) { create(:imported_client, agency: user_agency, first_name: 'ClientUserAgency') }
+    let!(:client_other_agency) { create(:imported_client, agency: other_agency, first_name: 'ClientOtherAgency') }
+    let!(:client_nil_agency) { create(:imported_client, agency: nil, first_name: 'ClientNilAgency') }
+
+    # For testing visible_through_user_agency indirectly
+    let!(:client_covid_pathway_other_agency) do
+      client = create(:imported_client, agency: other_agency, first_name: 'ClientCovidOtherAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
+      client
+    end
+
+    let!(:client_covid_pathway_user_agency) do
+      client = create(:imported_client, agency: user_agency, first_name: 'ClientCovidUserAgency')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
+      client
+    end
+
+    context 'when user has a role with can_edit_all_clients?' do
+      it 'returns all imported clients' do
+        scope_results = described_class.visible_to(user_with_edit_all_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has a role with can_manage_imported_clients?' do
+      it 'returns all imported clients' do
+        scope_results = described_class.visible_to(user_with_manage_imported_role)
+        expect(scope_results).to contain_exactly(client_user_agency, client_other_agency, client_nil_agency, client_covid_pathway_other_agency, client_covid_pathway_user_agency)
+      end
+    end
+
+    context 'when user has basic role and can_view_all_covid_pathways?' do
+      it 'returns clients from user agency, nil agency, and those with COVID pathway assessments' do
+        scope_results = described_class.visible_to(user_with_covid_pathways_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency,
+          client_covid_pathway_other_agency,
+        )
+        expect(scope_results).not_to include(client_other_agency)
+      end
+    end
+
+    context 'when user has basic role and cannot_view_all_covid_pathways?' do
+      it 'returns clients from user agency and nil agency only' do
+        scope_results = described_class.visible_to(user_with_basic_role)
+        expect(scope_results).to contain_exactly(
+          client_user_agency,
+          client_nil_agency,
+          client_covid_pathway_user_agency,
+        )
+        expect(scope_results).not_to include(client_other_agency)
+        expect(scope_results).not_to include(client_covid_pathway_other_agency)
+      end
+    end
+  end
+end

--- a/spec/models/non_hmis_client_spec.rb
+++ b/spec/models/non_hmis_client_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NonHmisClient, type: :model do
+  describe '.visible_through_user_agency' do
+    let!(:user_agency) { create(:agency, name: 'User Agency') }
+    let!(:other_agency) { create(:agency, name: 'Other Agency') }
+
+    let!(:user_with_covid_pathways_permission) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'covid_viewer', can_view_all_covid_pathways: true)
+      user.roles << role
+      user
+    end
+
+    let!(:user_without_covid_pathways_permission) do
+      user = create(:user, agency: user_agency)
+      role = create(:role, name: 'no_covid_viewer', can_view_all_covid_pathways: false)
+      user.roles << role
+      user
+    end
+
+    # Clients (using deidentified_client factory as a concrete NonHmisClient)
+    let!(:client_user_agency) { create(:deidentified_client, agency: user_agency, first_name: 'CUA') }
+    let!(:client_other_agency) { create(:deidentified_client, agency: other_agency, first_name: 'COA') }
+    let!(:client_nil_agency) { create(:deidentified_client, agency: nil, first_name: 'CNA') }
+
+    # Assessments
+    let!(:client_with_limitable_assessment_user_agency) do
+      client = create(:deidentified_client, agency: user_agency, first_name: 'CLAUA')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: user_agency)
+      client
+    end
+
+    let!(:client_with_limitable_assessment_other_agency) do
+      client = create(:deidentified_client, agency: other_agency, first_name: 'CLAOA')
+      create(:non_hmis_assessment, :limitable_pathway, non_hmis_client: client, agency: other_agency)
+      client
+    end
+
+    let!(:client_with_non_limitable_assessment_other_agency) do
+      client = create(:deidentified_client, agency: other_agency, first_name: 'CNLAOA')
+      create(:non_hmis_assessment, :non_limitable_pathway, non_hmis_client: client, agency: other_agency)
+      client
+    end
+
+    context 'when user has can_view_all_covid_pathways? permission' do
+      subject(:scope_results) { described_class.visible_through_user_agency(user_with_covid_pathways_permission) }
+
+      it 'includes clients from user\'s agency' do
+        expect(scope_results).to include(client_user_agency)
+      end
+
+      it 'includes clients with nil agency' do
+        expect(scope_results).to include(client_nil_agency)
+      end
+
+      it 'includes clients with limitable pathway assessments from user\'s agency' do
+        expect(scope_results).to include(client_with_limitable_assessment_user_agency)
+      end
+
+      it 'includes clients with limitable pathway assessments from other agencies' do
+        expect(scope_results).to include(client_with_limitable_assessment_other_agency)
+      end
+
+      it 'does not include clients from other agencies without limitable pathways' do
+        expect(scope_results).not_to include(client_other_agency)
+      end
+
+      it 'does not include clients with non-limitable assessments from other agencies' do
+        expect(scope_results).not_to include(client_with_non_limitable_assessment_other_agency)
+      end
+
+      it 'returns a distinct list of clients' do
+        # client_with_limitable_assessment_user_agency is visible due to agency AND pathway
+        expect(scope_results.where(id: client_with_limitable_assessment_user_agency.id).count).to eq(1)
+      end
+    end
+
+    context 'when user does not have can_view_all_covid_pathways? permission' do
+      subject(:scope_results) { described_class.visible_through_user_agency(user_without_covid_pathways_permission) }
+
+      it 'includes clients from user\'s agency' do
+        expect(scope_results).to include(client_user_agency)
+      end
+
+      it 'includes clients with nil agency' do
+        expect(scope_results).to include(client_nil_agency)
+      end
+
+      it 'includes clients with limitable pathway assessments from user\'s agency (due to agency match)' do
+        expect(scope_results).to include(client_with_limitable_assessment_user_agency)
+      end
+
+      it 'does not include clients from other agencies without limitable pathways' do
+        expect(scope_results).not_to include(client_other_agency)
+      end
+
+      it 'does not include clients with limitable pathway assessments from other agencies' do
+        expect(scope_results).not_to include(client_with_limitable_assessment_other_agency)
+      end
+
+      it 'does not include clients with non-limitable assessments from other agencies' do
+        expect(scope_results).not_to include(client_with_non_limitable_assessment_other_agency)
+      end
+    end
+  end
+end

--- a/spec/requests/non_hmis_assessments_spec.rb
+++ b/spec/requests/non_hmis_assessments_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'NonHmisAssessments', type: :request do
+  let!(:user_agency) { create(:agency, name: 'User Agency') }
+  let!(:other_agency) { create(:agency, name: 'Other Agency') }
+
+  # Roles
+  let!(:identified_manager_role) { create(:role, name: 'identified_manager_assessment_test', can_manage_all_identified_clients: true) }
+  let!(:deidentified_manager_role) { create(:role, name: 'deidentified_manager_assessment_test', can_manage_all_deidentified_clients: true) }
+  let!(:basic_role) { create(:role, name: 'basic_user_assessment_test_role') }
+
+  # Users
+  let!(:identified_manager_user) { create(:user, agency: user_agency, roles: [identified_manager_role]) }
+  let!(:deidentified_manager_user) { create(:user, agency: user_agency, roles: [deidentified_manager_role]) }
+  let!(:basic_user) { create(:user, agency: user_agency, roles: [basic_role]) }
+
+  # Clients in Other Agency
+  # Ensure your factories set the 'identified' attribute correctly as per the .identified and .deidentified scopes used in the controller.
+  let!(:identified_client_other_agency) { create(:identified_client, agency: other_agency, identified: true) }
+  let!(:deidentified_client_other_agency) { create(:deidentified_client, agency: other_agency, identified: false) }
+
+  # Client in User's own agency (for basic user tests)
+  let!(:identified_client_user_agency) { create(:identified_client, agency: user_agency, identified: true) }
+  let!(:deidentified_client_user_agency) { create(:deidentified_client, agency: user_agency, identified: false) }
+
+  before do
+    # this flag prevents duplicate assessments are created due to after_initialize hooks
+    NonHmisClient.skip_build_assessment_if_missing = true
+  end
+
+  describe 'Identified Clients Assessments' do
+    let(:assessment_params) do
+      {
+        identified_client_assessment: attributes_for(:non_hmis_assessment, agency_id: user_agency.id, type: 'DeidentifiedCovidPathwaysAssessment'),
+      }
+    end
+
+    context 'when user has can_manage_all_identified_clients permission' do
+      before { sign_in identified_manager_user }
+
+      it 'allows access to the new assessment page for an identified client in another agency' do
+        get new_identified_client_non_hmis_assessment_path(identified_client_id: identified_client_other_agency.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows creating an assessment for an identified client in another agency' do
+        expect do
+          post identified_client_non_hmis_assessments_path(identified_client_id: identified_client_other_agency.id), params: assessment_params
+        end.to change(NonHmisAssessment, :count).by(1)
+        expect(response).to have_http_status(:redirect)
+        assessment = NonHmisAssessment.last
+        expect(assessment.non_hmis_client_id).to eq(identified_client_other_agency.id)
+        expect(assessment.agency_id).to eq(user_agency.id)
+      end
+    end
+
+    context 'when user is basic and lacks can_manage_all_identified_clients permission' do
+      before { sign_in basic_user }
+
+      it 'denies access to the new assessment page for an identified client in another agency' do
+        get new_identified_client_non_hmis_assessment_path(identified_client_id: identified_client_other_agency.id)
+      end
+
+      it 'denies creating an assessment for an identified client in another agency' do
+        post identified_client_non_hmis_assessments_path(identified_client_id: identified_client_other_agency.id), params: assessment_params
+        expect(response).to have_http_status(:not_found)
+        expect(NonHmisAssessment.count).to eq(0) # Ensure no assessment was created
+      end
+
+      it 'allows access to the new assessment page for an identified client in their own agency' do
+        get new_identified_client_non_hmis_assessment_path(identified_client_id: identified_client_user_agency.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows creating an assessment for an identified client in their own agency' do
+        expect do
+          post identified_client_non_hmis_assessments_path(identified_client_id: identified_client_user_agency.id), params: assessment_params
+        end.to change(NonHmisAssessment, :count).by(1)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  describe 'Deidentified Clients Assessments' do
+    let(:assessment_params) do
+      {
+        deidentified_client_assessment: attributes_for(:non_hmis_assessment, agency_id: user_agency.id, type: 'DeidentifiedCovidPathwaysAssessment'),
+      }
+    end
+    context 'when user has can_manage_all_deidentified_clients permission' do
+      before { sign_in deidentified_manager_user }
+
+      it 'allows access to the new assessment page for a deidentified client in another agency' do
+        get new_deidentified_client_non_hmis_assessment_path(deidentified_client_id: deidentified_client_other_agency.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows creating an assessment for a deidentified client in another agency' do
+        expect do
+          post deidentified_client_non_hmis_assessments_path(deidentified_client_id: deidentified_client_other_agency.id), params: assessment_params
+        end.to change(NonHmisAssessment, :count).by(1)
+        expect(response).to have_http_status(:redirect)
+        assessment = NonHmisAssessment.last
+        expect(assessment.non_hmis_client_id).to eq(deidentified_client_other_agency.id)
+        expect(assessment.agency_id).to eq(user_agency.id)
+      end
+    end
+
+    context 'when user is basic and lacks can_manage_all_deidentified_clients permission' do
+      before { sign_in basic_user }
+
+      it 'denies access to the new assessment page for a deidentified client in another agency' do
+        get new_deidentified_client_non_hmis_assessment_path(deidentified_client_id: deidentified_client_other_agency.id)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'denies creating an assessment for a deidentified client in another agency' do
+        post deidentified_client_non_hmis_assessments_path(deidentified_client_id: deidentified_client_other_agency.id), params: assessment_params
+        expect(response).to have_http_status(:not_found)
+        expect(NonHmisAssessment.count).to eq(0)
+      end
+
+      it 'allows access to the new assessment page for a deidentified client in their own agency' do
+        get new_deidentified_client_non_hmis_assessment_path(deidentified_client_id: deidentified_client_user_agency.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'allows creating an assessment for a deidentified client in their own agency' do
+        expect do
+          post deidentified_client_non_hmis_assessments_path(deidentified_client_id: deidentified_client_user_agency.id), params: assessment_params
+        end.to change(NonHmisAssessment, :count).by(1)
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/editable_by_shared_examples.rb
+++ b/spec/support/shared_examples/editable_by_shared_examples.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'client core visibility and editability' do |client_factory_name, perm_manage_all, perm_manage_non_all, perm_enter|
+  # --- Common Setup ---
+  let!(:user_agency) { create(:agency, name: "User Agency for #{client_factory_name}") }
+  let!(:other_agency) { create(:agency, name: "Other Agency for #{client_factory_name}") }
+
+  let!(:client_at_user_agency) { create(client_factory_name, agency: user_agency, first_name: "UserAgencyClient-#{client_factory_name.to_s.camelize}") }
+  let!(:client_at_other_agency) { create(client_factory_name, agency: other_agency, first_name: "OtherAgencyClient-#{client_factory_name.to_s.camelize}") }
+  let!(:client_nil_agency) { create(client_factory_name, agency: nil, first_name: "NilAgencyClient-#{client_factory_name.to_s.camelize}") }
+
+  let(:create_user_with_permission) do
+    ->(permission_to_set) do
+      user = create(:user, agency: user_agency)
+      role_attributes = {
+        name: "#{permission_to_set}_#{client_factory_name}",
+      }
+      # Initialize all relevant permissions to false, then set the desired one to true.
+      # Add :can_edit_all_clients to the list of perms to initialize for comprehensive role setup.
+      ([perm_manage_all, perm_manage_non_all, perm_enter, :can_edit_all_clients].uniq.compact - [nil]).each do |p|
+        role_attributes[p] = false
+      end
+      role_attributes[permission_to_set] = true if permission_to_set
+
+      role = create(:role, role_attributes)
+      user.roles << role
+      user
+    end
+  end
+
+  let(:basic_user) { create(:user, agency: user_agency) } # User with no special roles/permissions by default
+
+  let(:enable_pathways) do
+    -> {
+      record_class = build(client_factory_name).class
+      allow(record_class).to receive(:pathways_enabled?).and_return(true)
+    }
+  end
+
+  # --- Visibility Scope Tests (.visible_to) ---
+  context 'class method .visible_to(user) scope' do
+    let(:user_can_edit_all_globally_for_visibility) { create_user_with_permission.call(:can_edit_all_clients) }
+    # For this context, ensure the user *only* has perm_manage_all and not can_edit_all_clients
+    let(:user_with_only_manage_all_for_visibility) { create_user_with_permission.call(perm_manage_all) }
+
+    context 'when user has role with can_edit_all_clients' do
+      it 'returns all clients (user agency, other agency, nil agency)' do
+        scope_results = described_class.visible_to(user_can_edit_all_globally_for_visibility)
+        expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+      end
+    end
+
+    context 'when user has role with ONLY the specific manage_all permission' do
+      it 'returns all clients (user agency, other agency, nil agency)' do
+        scope_results = described_class.visible_to(user_with_only_manage_all_for_visibility)
+        expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+      end
+    end
+
+    context 'when user has a basic role (no broad visibility permissions)' do
+      it 'returns clients from their agency and nil agency only' do
+        scope_results = described_class.visible_to(basic_user)
+        expect(scope_results).to contain_exactly(client_at_user_agency, client_nil_agency)
+        expect(scope_results).not_to include(client_at_other_agency)
+      end
+    end
+  end
+
+  # --- Instance Method Tests (#editable_by?) ---
+  context 'instance method #editable_by?(user)' do
+    context 'when user has role with ONLY the specific manage_all permission' do
+      let(:user_with_only_manage_all_perm) { create_user_with_permission.call(perm_manage_all) }
+
+      it 'returns true for clients at their own agency' do
+        expect(client_at_user_agency.editable_by?(user_with_only_manage_all_perm)).to be true
+      end
+      it 'returns true for clients at other agencies' do
+        expect(client_at_other_agency.editable_by?(user_with_only_manage_all_perm)).to be true
+      end
+    end
+
+    context 'when user has role with ONLY the specific manage_non_all permission' do
+      let(:user_with_only_manage_non_all_perm) { create_user_with_permission.call(perm_manage_non_all) }
+
+      it 'returns true for clients at their own agency' do
+        expect(client_at_user_agency.editable_by?(user_with_only_manage_non_all_perm)).to be true
+      end
+      it 'returns true for clients at other agencies' do
+        expect(client_at_other_agency.editable_by?(user_with_only_manage_non_all_perm)).to be true
+      end
+    end
+
+    context 'when user has role with ONLY the specific enter permission' do
+      let(:user_with_only_enter_perm) { create_user_with_permission.call(perm_enter) }
+
+      context 'and pathways are disabled' do
+        it 'returns true for clients at their own agency' do
+          expect(client_at_user_agency.editable_by?(user_with_only_enter_perm)).to be true
+        end
+        it 'returns false for clients at other agencies' do
+          expect(client_at_other_agency.editable_by?(user_with_only_enter_perm)).to be false
+        end
+      end
+
+      context 'and pathways are enabled' do
+        before { enable_pathways.call }
+        it 'returns true for clients at their own agency' do
+          expect(client_at_user_agency.editable_by?(user_with_only_enter_perm)).to be true
+        end
+        it 'returns true for clients at other agencies' do
+          expect(client_at_other_agency.editable_by?(user_with_only_enter_perm)).to be true
+        end
+      end
+    end
+
+    context 'when user has no relevant permissions (basic_user)' do
+      it 'returns false for clients at their own agency' do
+        expect(client_at_user_agency.editable_by?(basic_user)).to be false
+      end
+      it 'returns false for clients at other agencies' do
+        expect(client_at_other_agency.editable_by?(basic_user)).to be false
+      end
+    end
+  end
+
+  # --- Scope Tests (.editable_by) ---
+  context 'class method .editable_by(user) scope' do
+    let(:user_can_edit_all_globally) { create_user_with_permission.call(:can_edit_all_clients) }
+    let(:user_with_only_manage_all_scope_perm) { create_user_with_permission.call(perm_manage_all) }
+    let(:user_with_only_manage_non_all_scope_perm) { create_user_with_permission.call(perm_manage_non_all) }
+    let(:user_with_only_enter_scope_perm) { create_user_with_permission.call(perm_enter) }
+
+    context 'when user has role with can_edit_all_clients' do
+      it 'returns all clients (user agency, other agency, nil agency)' do
+        scope_results = described_class.editable_by(user_can_edit_all_globally)
+        expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+      end
+    end
+
+    context 'when user has role with ONLY the specific manage_all permission' do
+      it 'returns all clients (user agency, other agency, nil agency)' do
+        scope_results = described_class.editable_by(user_with_only_manage_all_scope_perm)
+        expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+      end
+    end
+
+    context 'when user has role with ONLY the specific manage_non_all permission' do
+      context 'and pathways are disabled' do
+        it 'returns clients from their agency only' do
+          scope_results = described_class.editable_by(user_with_only_manage_non_all_scope_perm)
+          expect(scope_results).to contain_exactly(client_at_user_agency)
+          expect(scope_results).not_to include(client_at_other_agency, client_nil_agency)
+        end
+      end
+      context 'and pathways are enabled' do
+        before { enable_pathways.call }
+        it 'returns all clients (user agency, other agency, nil agency)' do
+          scope_results = described_class.editable_by(user_with_only_manage_non_all_scope_perm)
+          expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+        end
+      end
+    end
+
+    context 'when user has role with ONLY the specific enter permission' do
+      context 'and pathways are disabled' do
+        it 'returns clients from their agency only' do
+          scope_results = described_class.editable_by(user_with_only_enter_scope_perm)
+          expect(scope_results).to contain_exactly(client_at_user_agency)
+          expect(scope_results).not_to include(client_at_other_agency, client_nil_agency)
+        end
+      end
+      context 'and pathways are enabled' do
+        before { enable_pathways.call }
+        it 'returns all clients (user agency, other agency, nil agency)' do
+          scope_results = described_class.editable_by(user_with_only_enter_scope_perm)
+          expect(scope_results).to contain_exactly(client_at_user_agency, client_at_other_agency, client_nil_agency)
+        end
+      end
+    end
+
+    context 'when user has no relevant editing permissions (basic_user)' do
+      it 'returns no clients' do
+        scope_results = described_class.editable_by(basic_user)
+        expect(scope_results).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
fixes to permission checks on clients and assessments
* fix permissions for identified/de-identified clients in assessment controller client and assessment loaders
* fix permissions in client.remote_visible_to
* correct permissions in the visible_to scope in the client child classes (DeidentifiedClient, IdentifiedClient, and Imported Client). Also DRY up the agency permission check
* remove unused visible_by and editable_by from NonHmisAssessment
* upgrade rubocop, it was crashing while trying to lint the specs


## Type of change
Bug fix, tests

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
