### PR TITLE
Allow updating of expiration date regardless of step

### DIFF
--- a/app/controllers/match_decisions_controller.rb
+++ b/app/controllers/match_decisions_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class MatchDecisionsController < ApplicationController
   include HasMatchAccessContext
   include Decisions
@@ -42,6 +44,7 @@ class MatchDecisionsController < ApplicationController
     @types = MatchRoutes::Base.match_steps
 
     @match_contacts.update match_contacts_params if params[:match_contacts].present?
+
     # If the match is already expired, and we're un-expiring it, then allow it
     if @match.expired? && params[:commit] == 'Save Expiration Date' && can_reject_matches? && decision_params[:shelter_expiration].present?
       original_status = @decision.status
@@ -94,6 +97,10 @@ class MatchDecisionsController < ApplicationController
       flash[:error] = 'Sorry, you can only disable a vacancy when cancelling a match'
       render 'matches/show'
 
+    elsif only_updating_expiration?
+      change_expiration
+      flash[:notice] = 'The expiration date has been updated.' unless request.xhr?
+      redirect_to access_context.match_path(@match, redirect: 'true')
     elsif @decision.update(decision_params)
       # Wrapped in a transaction to prevent the match match engine (which runs in parallel) from seeing
       # partial updates
@@ -145,6 +152,14 @@ class MatchDecisionsController < ApplicationController
       flash[:error] = "Please review the form problems below.<br /> #{@decision.errors.full_messages.join('; ')}"
       render 'matches/show'
     end
+  end
+
+  private def only_updating_expiration?
+    decision_params[:shelter_expiration].present? &&
+      decision_params[:status] == 'expiration_update' &&
+      decision_params[:prevent_matching_until].blank? &&
+      decision_params[:administrative_cancel_reason_id].blank? &&
+      decision_params[:decline_reason_id].blank?
   end
 
   private def change_expiration

--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class Opportunity < ApplicationRecord
   acts_as_paranoid
   has_paper_trail
@@ -166,11 +168,11 @@ class Opportunity < ApplicationRecord
   # Return prioritized clients who match this opportunity
   def matching_clients(client_scope = Client.available_for_matching(match_route))
     requirements_with_inherited.each do |requirement|
-      client_scope = client_scope.merge(requirement.clients_that_fit(client_scope, self), rewhere: true)
+      client_scope = client_scope.merge(requirement.clients_that_fit(client_scope, self))
     end
     client_scope = add_unit_attributes_filter(client_scope)
     client_scope = client_scope.not_rejected_for(id)
-    client_scope.merge(Client.prioritized(active_prioritization_scheme, client_scope), rewhere: true)
+    client_scope.merge(Client.prioritized(active_prioritization_scheme, client_scope))
   end
 
   def add_unit_attributes_filter(client_scope)


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Fixes https://github.com/open-path/Green-River/issues/7828 by allowing saving of the expiration date if that's the only thing being changed.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix
* Unassociated deprecation fix (removed rewhere: true) which was only needed in Rails 6.1

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
