### PR TITLE
Entrypoint syntax fixes

### DIFF
--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 
 # Exit on any error
 # set -e
@@ -6,21 +6,20 @@
 # auto-export variables
 set -a
 
-if [ "${EKS}" != "true" ]
-then
+if [[ "${EKS}" != "true" ]]; then
   echo Getting Role Info
-  curl --silent 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI > role.info.log
+  curl --silent 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI >role.info.log
 
   cd /app
 
   echo 'Getting secrets for the environment...'
-  T1=`date +%s`
-  bundle exec ./bin/download_secrets.rb > .env
+  T1=$(date +%s)
+  bundle exec ./bin/download_secrets.rb >.env
   if [ ! -f .env ]; then
     echo "Failed to create .env file"
-      exit 1
+    exit 1
   fi
-  T2=`date +%s`
+  T2=$(date +%s)
   echo "...secrets took $(expr $T2 - $T1) seconds"
 
   echo Sourcing environment
@@ -28,17 +27,17 @@ then
 fi
 
 echo 'Constructing an ERB-free database.yml file...'
-T1=`date +%s`
+T1=$(date +%s)
 bundle exec ./bin/materialize.database.yaml.rb
-T2=`date +%s`
+T2=$(date +%s)
 echo "...database materialize took $(expr $T2 - $T1) seconds"
 
 echo 'Setting Timezone'
 cp /usr/share/zoneinfo/$TIMEZONE /app/etc-localtime
-echo $TIMEZONE > /etc/timezone
+echo $TIMEZONE >/etc/timezone
 
-if [ "$CONTAINER_VARIANT" == "dj" ]; then
-  if [ "${ENABLE_DJ_METRICS}" = "true" ] ; then
+if [[ "$CONTAINER_VARIANT" == "dj" ]]; then
+  if [[ "${ENABLE_DJ_METRICS}" = "true" ]]; then
     echo "Starting metrics server"
     # not cluster mode with 5 threads
     bundle exec puma --no-config -w 0 -t 1:5 /app/dj-metrics/config.ru &
@@ -55,17 +54,17 @@ fi
 # echo "...sync_app_assets 1 took $(expr $T2 - $T1) seconds"
 
 echo 'Clobbering assets...'
-T1=`date +%s`
+T1=$(date +%s)
 ./bin/rake assets:clobber && mkdir -p ./public/assets
-T2=`date +%s`
+T2=$(date +%s)
 echo "...clobbering took $(expr $T2 - $T1) seconds"
 
-T1=`date +%s`
+T1=$(date +%s)
 ASSET_CHECKSUM=$(ASSETS_PREFIX=${ASSETS_PREFIX} ./bin/asset_checksum) # This should return the same hash as the call in asset_compiler.rb
-T2=`date +%s`
+T2=$(date +%s)
 echo "...checksumming took $(expr $T2 - $T1) seconds"
 
-if grep 'Access denied' asset.checksum.log > /dev/null 2>&1; then
+if grep 'Access denied' asset.checksum.log >/dev/null 2>&1; then
   echo "Looks like you cannot access the assets bucket. Check your IAM permissions"
 fi
 
@@ -77,13 +76,13 @@ echo "Using ASSET_CHECKSUM [${ASSET_CHECKSUM}]"
 echo 'Pulling down the compiled assets...' # Using ASSETS_PREFIX from .env and ASSET_CHECKSUM from above.
 cd ./public/assets
 
-if [ "$CONTAINER_VARIANT" == "deploy" ]; then
+if [[ "$CONTAINER_VARIANT" == "deploy" ]]; then
   bundle exec /app/bin/wait_for_compiled_assets.rb || exit 1
 fi
 
-T1=`date +%s`
+T1=$(date +%s)
 ASSETS_PREFIX="${ASSETS_PREFIX}/${ASSET_CHECKSUM}" ASSETS_BUCKET_NAME=openpath-precompiled-assets UPDATE_ONLY=true bundle exec /app/bin/sync_app_assets.rb
-T2=`date +%s`
+T2=$(date +%s)
 echo "...pulling compiled assets took $(expr $T2 - $T1) seconds"
 cd ../..
 


### PR DESCRIPTION
- Fixes shell syntax errors
- Lints the script

## _Merging this PR_

## Description
I think the move from alpine left us with different shell behavior, and we usually use double brackets for comparisons with the double equals. The single brackets are for operators like `-eq`. Figured bash is more powerful anyway, so changes to that.

## Type of change
bugfix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)


## Testing
I ran this in a container to test before and after the change:


```
EKS=true ./docker/app/entrypoint.sh echo foo
```
