### PR TITLE
Add a confirmation modal to the moving of matches from one contact to another

### DIFF
--- a/app/views/contacts/move_matches.haml
+++ b/app/views/contacts/move_matches.haml
@@ -14,6 +14,6 @@
         = f.input :destination, collection: @contacts, label: 'Assign match contacts to', input_html: { class: :select2 }, include_blank: 'Remove Contact from All Matches'
 
       .form-actions
-        = f.button :submit, value: 'Move All Contacts'
+        = f.button :submit, value: 'Move All Contacts', data: { confirm: 'Moving all matches is not easily reversible.  Are you sure you want to continue?' }
 
 = render 'init_select2'

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -80,25 +80,6 @@
       "note": ""
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.1.5.1 ends on 2025-10-01",
-      "file": "Gemfile.lock",
-      "line": 1114,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Command Injection",
       "warning_code": 14,
       "fingerprint": "272bd9135442f395012a87ac47a02fe2dcaa8bf8f7db7b78b079036a4279e439",
@@ -470,6 +451,25 @@
         77
       ],
       "note": "We're just injecting the git revision."
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.1.5.2 ends on 2025-10-01",
+      "file": "Gemfile.lock",
+      "line": 1114,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
     },
     {
       "warning_type": "Dynamic Render Path",


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Ignores Rails 7.1 EOL, handled in another PR
* Adds a confirmation modal to the page where you can move matches from one contact to another since there is no easy undo

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail

