### PR TITLE
Persist filters and sort across searches; redirect to non-search result if search query is empty

### DIFF
--- a/app/controllers/active_match_search_queries_controller.rb
+++ b/app/controllers/active_match_search_queries_controller.rb
@@ -17,7 +17,7 @@ class ActiveMatchSearchQueriesController < ActiveMatchesController
 
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to active_match_search_query_path(sanitized_search_params.merge(id: query.id, current_route: @current_route_name).symbolize_keys)
+      redirect_to active_match_search_query_path(sanitized_search_params.merge(id: query.id, current_route: @current_route_name))
     else
       flash[:error] = 'Search query not valid'
       redirect_to active_matches_path

--- a/app/controllers/active_match_search_queries_controller.rb
+++ b/app/controllers/active_match_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class ActiveMatchSearchQueriesController < ActiveMatchesController
   def create
     safe_params = ClientSearchQuery.permit_params(params)
+
+    if safe_params[:q].blank?
+      redirect_to active_matches_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to active_match_search_query_path(id: query.id, current_route: @current_route_name)
+      redirect_to active_match_search_query_path(sanitized_search_params.merge(id: query.id, current_route: @current_route_name).symbolize_keys)
     else
       flash[:error] = 'Search query not valid'
       redirect_to active_matches_path

--- a/app/controllers/admin/user_search_queries_controller.rb
+++ b/app/controllers/admin/user_search_queries_controller.rb
@@ -10,12 +10,17 @@ module Admin
   class UserSearchQueriesController < Admin::UsersController
     def create
       safe_params = ClientSearchQuery.permit_params(params)
+      if safe_params[:q].blank?
+        redirect_to admin_users_path(sanitized_search_params)
+        return
+      end
+
       query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
       if query.valid?
-        redirect_to admin_user_search_query_path(id: query.id)
+        redirect_to admin_user_search_query_path(sanitized_search_params.merge(id: query.id))
       else
         flash[:error] = 'Search query not valid'
-        redirect_to admin_user_search_queries_path
+        redirect_to admin_users_path
         return
       end
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,7 +48,7 @@ module Admin
 
       # sort / paginate
       @users = @users
-        .order(sort_column => sort_direction)
+        .reorder(sort_column => sort_direction)
         .page(params[:page]).per(25)
 
       # count number of active/closed matches per user

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -178,6 +178,11 @@ module Admin
       )
     end
 
+    def sanitized_search_params
+      params.permit(:direction, :sort).to_h.symbolize_keys
+    end
+    helper_method :sanitized_search_params
+
     def confirmation_params
       params.require(:user).permit(
         :confirmation_password,

--- a/app/controllers/client_search_queries_controller.rb
+++ b/app/controllers/client_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class ClientSearchQueriesController < ClientsController
   def create
     safe_params = ClientSearchQuery.permit_params(params[:search_form])
+
+    if safe_params[:q].blank?
+      redirect_to clients_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to client_search_query_path(id: query.id)
+      redirect_to client_search_query_path(sanitized_search_params.merge(id: query.id))
     else
       flash[:error] = 'Search query not valid'
       redirect_to clients_path

--- a/app/controllers/clients_controller.rb
+++ b/app/controllers/clients_controller.rb
@@ -94,6 +94,11 @@ class ClientsController < ApplicationController
     }.compact
   end
 
+  def sanitized_search_params
+    search_params.to_h.symbolize_keys.except(:q)
+  end
+  helper_method :sanitized_search_params
+
   private def search_scope
     client_scope
   end

--- a/app/controllers/closed_match_search_queries_controller.rb
+++ b/app/controllers/closed_match_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class ClosedMatchSearchQueriesController < ClosedMatchesController
   def create
     safe_params = ClientSearchQuery.permit_params(params)
+
+    if safe_params[:q].blank?
+      redirect_to closed_matches_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to closed_match_search_query_path(id: query.id, current_route: @current_route_name)
+      redirect_to closed_match_search_query_path(sanitized_search_params.merge(id: query.id, current_route: @current_route_name))
     else
       flash[:error] = 'Search query not valid'
       redirect_to closed_matches_path

--- a/app/controllers/deidentified_client_search_queries_controller.rb
+++ b/app/controllers/deidentified_client_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class DeidentifiedClientSearchQueriesController < DeidentifiedClientsController
   def create
     safe_params = ClientSearchQuery.permit_params(params[:search_form])
+
+    if safe_params[:q].blank?
+      redirect_to deidentified_clients_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to deidentified_client_search_query_path(id: query.id)
+      redirect_to deidentified_client_search_query_path(sanitized_search_params.merge(id: query.id))
     else
       flash[:error] = 'Search query not valid'
       redirect_to deidentified_clients_path

--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -120,8 +120,8 @@ class DeidentifiedClientsController < NonHmisClientsController
       { title: 'Agency Z-A', column: 'agencies.name', direction: 'desc', order: 'LOWER(agencies.name) DESC', visible: true },
       { title: 'Assessment Score', column: 'assessment_score', direction: 'desc', order: 'non_hmis_clients.assessment_score DESC', visible: true },
       { title: 'Assessment Date', column: 'assessed_at', direction: 'desc', order: 'non_hmis_clients.assessed_at DESC', visible: true },
-      { title: 'Days Homeless in the Last 3 Years', column: 'days_homeless_in_the_last_three_years', direction: 'desc',
-        order: 'days_homeless_in_the_last_three_years DESC', visible: true },
+      { title: 'Days Homeless in the Last 3 Years', column: 'non_hmis_clients.days_homeless_in_the_last_three_years', direction: 'desc',
+        order: 'non_hmis_clients.days_homeless_in_the_last_three_years DESC', visible: true },
     ].freeze
   end
   helper_method :sort_options

--- a/app/controllers/identified_client_search_queries_controller.rb
+++ b/app/controllers/identified_client_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class IdentifiedClientSearchQueriesController < IdentifiedClientsController
   def create
     safe_params = ClientSearchQuery.permit_params(params[:search_form])
+
+    if safe_params[:q].blank?
+      redirect_to identified_clients_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to identified_client_search_query_path(id: query.id)
+      redirect_to identified_client_search_query_path(sanitized_search_params.merge(id: query.id))
     else
       flash[:error] = 'Search query not valid'
       redirect_to identified_clients_path

--- a/app/controllers/identified_clients_controller.rb
+++ b/app/controllers/identified_clients_controller.rb
@@ -75,8 +75,8 @@ class IdentifiedClientsController < NonHmisClientsController
       { title: 'Agency Z-A', column: 'agencies.name', direction: 'desc', order: 'LOWER(agencies.name) DESC', visible: true },
       { title: 'Assessment Score', column: 'assessment_score', direction: 'desc', order: 'non_hmis_clients.assessment_score DESC', visible: true },
       { title: 'Assessment Date', column: 'assessed_at', direction: 'desc', order: 'non_hmis_clients.assessed_at DESC', visible: true },
-      { title: 'Days Homeless in the Last 3 Years', column: 'days_homeless_in_the_last_three_years', direction: 'desc',
-        order: 'days_homeless_in_the_last_three_years DESC', visible: true },
+      { title: 'Days Homeless in the Last 3 Years', column: 'non_hmis_clients.days_homeless_in_the_last_three_years', direction: 'desc',
+        order: 'non_hmis_clients.days_homeless_in_the_last_three_years DESC', visible: true },
     ].freeze
   end
   helper_method :sort_options

--- a/app/controllers/imported_client_search_queries_controller.rb
+++ b/app/controllers/imported_client_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class ImportedClientSearchQueriesController < ImportedClientsController
   def create
     safe_params = ClientSearchQuery.permit_params(params[:search_form])
+
+    if safe_params[:q].blank?
+      redirect_to imported_clients_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to imported_client_search_query_path(id: query.id)
+      redirect_to imported_client_search_query_path(sanitized_search_params.merge(id: query.id))
     else
       flash[:error] = 'Search query not valid'
       redirect_to imported_clients_path

--- a/app/controllers/imported_clients_controller.rb
+++ b/app/controllers/imported_clients_controller.rb
@@ -91,6 +91,24 @@ class ImportedClientsController < NonHmisClientsController
   end
   helper_method :sort_options
 
+  def sorter
+    @column = params[:sort]
+    @direction = params[:direction]
+    default_sort = sort_options.first.try(:[], :order)
+
+    sort_string = if @column.blank?
+      @column = sort_options.first.try(:[], :column)
+      @direction = sort_options.first.try(:[], :direction)
+      default_sort
+    else
+      sort_options.select do |m|
+        m[:column] == @column && m[:direction] == @direction
+      end.try(:first).try(:[], :order) || default_sort
+    end
+    sort_string += ' NULLS LAST' if ApplicationRecord.connection.adapter_name == 'PostgreSQL'
+    sort_string
+  end
+
   def filter_terms
     [:family_member, :available]
   end

--- a/app/controllers/match_list_base_controller.rb
+++ b/app/controllers/match_list_base_controller.rb
@@ -325,4 +325,23 @@ class MatchListBaseController < ApplicationController
     )
   end
   helper_method :filter_params
+
+  def search_params
+    params.permit(
+      :q,
+      :current_route,
+      :sort,
+      :direction,
+      :current_step,
+      :current_program,
+      :current_contact_type,
+      :current_filter_contact,
+    )
+  end
+  helper_method :search_params
+
+  def sanitized_search_params
+    search_params.to_h.symbolize_keys.except(:q)
+  end
+  helper_method :sanitized_search_params
 end

--- a/app/controllers/non_hmis_clients_controller.rb
+++ b/app/controllers/non_hmis_clients_controller.rb
@@ -219,7 +219,7 @@ class NonHmisClientsController < ApplicationController
           @column = 'assessed_at'
         end
       else
-        @column = 'days_homeless_in_the_last_three_years'
+        @column = 'non_hmis_clients.days_homeless_in_the_last_three_years'
       end
       @direction = 'desc'
       sort_string = "#{@column} #{@direction}"

--- a/app/controllers/non_hmis_clients_controller.rb
+++ b/app/controllers/non_hmis_clients_controller.rb
@@ -17,7 +17,7 @@ class NonHmisClientsController < ApplicationController
   before_action :load_contacts, only: [:new, :edit]
   before_action :set_active_filter, only: [:index, :search]
   before_action :find_match, only: [:current_assessment_limited]
-  around_action :with_skip_build_assessment_if_missing, only: [:index]
+  around_action :with_skip_build_assessment_if_missing, only: [:index, :search]
 
   helper_method :non_hmis_client_search_queries_path
 
@@ -73,10 +73,17 @@ class NonHmisClientsController < ApplicationController
       assessment: params[:assessment],
       available: params[:available],
       agency: params[:agency],
+      family_member: params[:family_member],
+      cohort: params[:cohort],
       sort: @column,
       direction: @direction,
     }.compact
   end
+
+  def sanitized_search_params
+    search_params.to_h.symbolize_keys.except(:q)
+  end
+  helper_method :sanitized_search_params
 
   private def handle_invalid_query(message)
     flash[:error] = message
@@ -219,7 +226,7 @@ class NonHmisClientsController < ApplicationController
     else
       sort_string = sort_options.select do |m|
         m[:column] == @column && m[:direction] == @direction
-      end.first[:order]
+      end.try(:first).try(:[], :order) || sort_options.first.try(:[], :order)
     end
 
     sort_string += ' NULLS LAST' if ApplicationRecord.connection.adapter_name == 'PostgreSQL'

--- a/app/controllers/unavailable_client_search_queries_controller.rb
+++ b/app/controllers/unavailable_client_search_queries_controller.rb
@@ -9,9 +9,15 @@
 class UnavailableClientSearchQueriesController < UnavailableClientsController
   def create
     safe_params = ClientSearchQuery.permit_params(params[:search_form])
+
+    if safe_params[:q].blank?
+      redirect_to unavailable_clients_path(sanitized_search_params)
+      return
+    end
+
     query = ClientSearchQuery.find_or_create_by_params(safe_params, user: current_user)
     if query.valid?
-      redirect_to unavailable_client_search_query_path(id: query.id)
+      redirect_to unavailable_client_search_query_path(sanitized_search_params.merge(id: query.id))
     else
       flash[:error] = 'Search query not valid'
       redirect_to unavailable_clients_path

--- a/app/views/active_matches/index.html.haml
+++ b/app/views/active_matches/index.html.haml
@@ -19,7 +19,7 @@
 
 .row
   .col-sm-4
-    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', current_route: @current_route_name, url: active_match_search_queries_path, method: :post
+    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: active_match_search_queries_path, method: :post, search_params: search_params.to_h.symbolize_keys.merge(current_route: @current_route_name)
 
   .col-sm-8.sort-filter.d-flex
     = render 'filter', available_steps: @available_steps, return_path: active_matches_path, label_method: :active, available_routes: @available_routes

--- a/app/views/active_matches/index.html.haml
+++ b/app/views/active_matches/index.html.haml
@@ -19,7 +19,7 @@
 
 .row
   .col-sm-4
-    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: active_match_search_queries_path, method: :post, search_params: search_params.to_h.symbolize_keys.merge(current_route: @current_route_name)
+    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: active_match_search_queries_path, method: :post, search_params: sanitized_search_params.merge(current_route: @current_route_name)
 
   .col-sm-8.sort-filter.d-flex
     = render 'filter', available_steps: @available_steps, return_path: active_matches_path, label_method: :active, available_routes: @available_routes

--- a/app/views/active_matches/index.html.haml
+++ b/app/views/active_matches/index.html.haml
@@ -19,7 +19,7 @@
 
 .row
   .col-sm-4
-    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: active_match_search_queries_path, method: :post, search_params: sanitized_search_params.merge(current_route: @current_route_name)
+    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: active_match_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params.merge(current_route: @current_route_name)
 
   .col-sm-8.sort-filter.d-flex
     = render 'filter', available_steps: @available_steps, return_path: active_matches_path, label_method: :active, available_routes: @available_routes

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -12,7 +12,7 @@
 
   .row
     .col-sm-6
-      = render 'search_form', url: admin_user_search_queries_path, method: :post
+      = render 'search_form', url: admin_user_search_queries_path, method: :post, search_params: sanitized_search_params
 
 %ul.nav.nav-tabs
   %li.nav-item

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -12,7 +12,7 @@
 
   .row
     .col-sm-6
-      = render 'search_form', url: admin_user_search_queries_path, method: :post, search_params: sanitized_search_params
+      = render 'search_form', url: admin_user_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params
 
 %ul.nav.nav-tabs
   %li.nav-item

--- a/app/views/application/_search_form.html.haml
+++ b/app/views/application/_search_form.html.haml
@@ -10,6 +10,11 @@
     = hidden_field_tag :current_tab, params[:current_tab]
   - if defined?(current_route)
     = hidden_field_tag :current_route, current_route
+  - if defined?(sanitized_search_params)
+    - search_params.each do | key, value|
+      - next if value.blank?
+
+      = hidden_field_tag key, value
   - filter_terms.each do | term |
     - if params[term]
       = hidden_field_tag term, params[term]

--- a/app/views/application/_search_form.html.haml
+++ b/app/views/application/_search_form.html.haml
@@ -11,7 +11,7 @@
   - if defined?(current_route)
     = hidden_field_tag :current_route, current_route
   - if defined?(sanitized_search_params)
-    - search_params.each do | key, value|
+    - sanitized_search_params.each do | key, value|
       - next if value.blank?
 
       = hidden_field_tag key, value

--- a/app/views/clients/_search_form.html.haml
+++ b/app/views/clients/_search_form.html.haml
@@ -7,8 +7,8 @@
     = hidden_field_tag :sort, params[:sort]
   - if params[:direction]
     = hidden_field_tag :direction, params[:direction]
-  - if defined?(search_params)
-    - search_params.each do | key, value|
+  - if defined?(sanitized_search_params)
+    - sanitized_search_params.each do | key, value|
       - next if value.blank?
 
       = hidden_field_tag key, value

--- a/app/views/clients/_search_form.html.haml
+++ b/app/views/clients/_search_form.html.haml
@@ -7,6 +7,11 @@
     = hidden_field_tag :sort, params[:sort]
   - if params[:direction]
     = hidden_field_tag :direction, params[:direction]
+  - if defined?(search_params)
+    - search_params.each do | key, value|
+      - next if value.blank?
+
+      = hidden_field_tag key, value
   - filter_terms.each do | term |
     - if params[term]
       = hidden_field_tag term, params[term]

--- a/app/views/clients/index.html.haml
+++ b/app/views/clients/index.html.haml
@@ -2,7 +2,7 @@
 - @prompt = t '.search_prompt'
 .row
   .col-sm-4
-    = render 'search_form', destination: client_search_queries_path, method: :post
+    = render 'search_form', destination: client_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params
   .col-sm-8.filter-sort__filter.d-flex
     = render 'filter'
     = render 'sort', sort_options: Client.sort_options(show_vispdat: @show_vispdat)

--- a/app/views/closed_matches/index.html.haml
+++ b/app/views/closed_matches/index.html.haml
@@ -19,7 +19,7 @@
   - @prompt = t '.search_prompt'
 .row.o-search
   .col-sm-4.o-search__input-wrapper
-    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: closed_match_search_queries_path, method: :post, search_params: search_params.to_h.symbolize_keys.merge(current_route: @current_route_name)
+    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: closed_match_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params.merge(current_route: @current_route_name)
 
   .col-sm-8.sort-filter.o-search__actions
     = render 'filter', available_steps: ClientOpportunityMatch.closed_filter_options, return_path: closed_matches_path, label_method: :closed, available_routes: @available_routes

--- a/app/views/closed_matches/index.html.haml
+++ b/app/views/closed_matches/index.html.haml
@@ -19,7 +19,7 @@
   - @prompt = t '.search_prompt'
 .row.o-search
   .col-sm-4.o-search__input-wrapper
-    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', current_route: @current_route_name, url: closed_match_search_queries_path, method: :post
+    = render 'search_form', tooltip: 'Search with PersonalID or full or partial "first last" or "last, first" for more specific results', url: closed_match_search_queries_path, method: :post, search_params: search_params.to_h.symbolize_keys.merge(current_route: @current_route_name)
 
   .col-sm-8.sort-filter.o-search__actions
     = render 'filter', available_steps: ClientOpportunityMatch.closed_filter_options, return_path: closed_matches_path, label_method: :closed, available_routes: @available_routes

--- a/app/views/non_hmis_clients/_search_sort.haml
+++ b/app/views/non_hmis_clients/_search_sort.haml
@@ -1,6 +1,6 @@
 .row
   .col-sm-4
-    = render 'clients/search_form', destination: non_hmis_client_search_queries_path, method: :post, search_params: sanitized_search_params
+    = render 'clients/search_form', destination: non_hmis_client_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params
   .col-sm-4.filter-sort__filter.d-flex
     = render 'filter'
     = render 'clients/sort', sort_options: sort_options

--- a/app/views/non_hmis_clients/_search_sort.haml
+++ b/app/views/non_hmis_clients/_search_sort.haml
@@ -1,6 +1,6 @@
 .row
   .col-sm-4
-    = render 'clients/search_form', destination: non_hmis_client_search_queries_path, method: :post
+    = render 'clients/search_form', destination: non_hmis_client_search_queries_path, method: :post, search_params: sanitized_search_params
   .col-sm-4.filter-sort__filter.d-flex
     = render 'filter'
     = render 'clients/sort', sort_options: sort_options

--- a/app/views/unavailable_clients/index.html.haml
+++ b/app/views/unavailable_clients/index.html.haml
@@ -2,7 +2,7 @@
 - @prompt = t '.search_prompt'
 .row
   .col-sm-4
-    = render 'search_form', destination: unavailable_client_search_queries_path, method: :post
+    = render 'search_form', destination: unavailable_client_search_queries_path, method: :post, sanitized_search_params: sanitized_search_params
   .col-sm-8.filter-sort__filter.d-flex
     = render 'filter'
     = render 'sort', sort_options: Client.sort_options(show_vispdat: @show_vispdat)

--- a/spec/controllers/admin/user_search_queries_controller_spec.rb
+++ b/spec/controllers/admin/user_search_queries_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::UserSearchQueriesController, type: :controller do
       expect(query.query_params[:q]).to eq('alpha')
       expect(query.query_params[:sort]).to eq('last_name')
       expect(query.query_params[:direction]).to eq('asc')
-      expect(response).to redirect_to(admin_user_search_query_path(id: query.id))
+      expect(response).to redirect_to(admin_user_search_query_path(search_params.merge(id: query.id)))
     end
 
     it 'reuses an existing search query for identical parameters' do

--- a/spec/controllers/admin/user_search_queries_controller_spec.rb
+++ b/spec/controllers/admin/user_search_queries_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::UserSearchQueriesController, type: :controller do
       expect(query.query_params[:q]).to eq('alpha')
       expect(query.query_params[:sort]).to eq('last_name')
       expect(query.query_params[:direction]).to eq('asc')
-      expect(response).to redirect_to(admin_user_search_query_path(search_params.merge(id: query.id)))
+      expect(response).to redirect_to(admin_user_search_query_path(id: query.id, sort: 'last_name', direction: 'asc'))
     end
 
     it 'reuses an existing search query for identical parameters' do
@@ -32,7 +32,7 @@ RSpec.describe Admin::UserSearchQueriesController, type: :controller do
         post :create, params: { q: 'alpha', sort: 'last_name', direction: 'asc' }
       end.not_to change(ClientSearchQuery, :count)
 
-      expect(response).to redirect_to(admin_user_search_query_path(id: first_query.id))
+      expect(response).to redirect_to(admin_user_search_query_path(id: first_query.id, sort: 'last_name', direction: 'asc'))
     end
   end
 end

--- a/spec/requests/client_search_persistence_spec.rb
+++ b/spec/requests/client_search_persistence_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Client Search Persistence', type: :request do
   let!(:client) { create(:client) }
   let!(:identified_client) { create(:identified_client) }
   let!(:deidentified_client) { create(:deidentified_client) }
+  let(:default_sort) { { direction: 'desc', sort: 'days_homeless_in_last_three_years' } }
 
   before do
     sign_in admin
@@ -21,7 +22,7 @@ RSpec.describe 'Client Search Persistence', type: :request do
       end.to change(ClientSearchQuery, :count).by(1)
 
       search_query = ClientSearchQuery.last
-      expect(response).to redirect_to(client_search_query_path(search_query))
+      expect(response).to redirect_to(client_search_query_path(search_query, **default_sort))
     end
 
     it 'displays search results via persisted query URL' do
@@ -32,13 +33,14 @@ RSpec.describe 'Client Search Persistence', type: :request do
   end
 
   describe 'Deidentified client search persistence' do
+    let(:default_sort) { { direction: 'desc', sort: 'non_hmis_clients.days_homeless_in_the_last_three_years' } }
     it 'creates a search query and redirects on search' do
       expect do
         post deidentified_client_search_queries_path, params: { search_form: { q: 'jane doe' } }
       end.to change(ClientSearchQuery, :count).by(1)
 
       search_query = ClientSearchQuery.last
-      expect(response).to redirect_to(deidentified_client_search_query_path(search_query))
+      expect(response).to redirect_to(deidentified_client_search_query_path(search_query, **default_sort))
     end
 
     it 'displays search results via persisted query URL' do
@@ -49,13 +51,14 @@ RSpec.describe 'Client Search Persistence', type: :request do
   end
 
   describe 'Identified client search persistence' do
+    let(:default_sort) { { direction: 'desc', sort: 'non_hmis_clients.days_homeless_in_the_last_three_years' } }
     it 'creates a search query and redirects on search' do
       expect do
         post identified_client_search_queries_path, params: { search_form: { q: 'bob smith' } }
       end.to change(ClientSearchQuery, :count).by(1)
 
       search_query = ClientSearchQuery.last
-      expect(response).to redirect_to(identified_client_search_query_path(search_query))
+      expect(response).to redirect_to(identified_client_search_query_path(search_query, **default_sort))
     end
 
     it 'displays search results via persisted query URL' do
@@ -89,7 +92,7 @@ RSpec.describe 'Client Search Persistence', type: :request do
       end.to change(ClientSearchQuery, :count).by(1)
 
       search_query = ClientSearchQuery.last
-      expect(response).to redirect_to(unavailable_client_search_query_path(search_query))
+      expect(response).to redirect_to(unavailable_client_search_query_path(search_query, **default_sort))
     end
 
     it 'displays search results via persisted query URL' do
@@ -110,7 +113,7 @@ RSpec.describe 'Client Search Persistence', type: :request do
         post client_search_queries_path, params: { search_form: { q: 'john doe' } }
       end.not_to change(ClientSearchQuery, :count)
 
-      expect(response).to redirect_to(client_search_query_path(first_query))
+      expect(response).to redirect_to(client_search_query_path(first_query, **default_sort))
     end
   end
 end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Persists filters and sorts across searches
* Redirects to the index page with appropriate sort and filtering if search is empty
* Fixes sort issues on Imported Clients

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
