### PR TITLE
Allow month and year entry for de-identified clients

### DIFF
--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -155,6 +155,8 @@ class DeidentifiedClientsController < NonHmisClientsController
       :vispdat_priority_score,
       :shelter_name,
       :warehouse_client_id,
+      :month_of_birth,
+      :year_of_birth,
       active_cohort_ids: [],
       enrolled_project_ids: [],
       client_assessments_attributes: [
@@ -240,17 +242,34 @@ class DeidentifiedClientsController < NonHmisClientsController
     )
   end
 
-  private def append_client_identifier dirty_params
+  private def append_client_identifier(dirty_params)
     dirty_params[:last_name] = "Anonymous - #{dirty_params[:client_identifier]}"
     dirty_params[:first_name] = "Anonymous - #{dirty_params[:client_identifier]}"
 
     return dirty_params
   end
 
-  private def clean_params dirty_params
+  private def clean_params(dirty_params)
     dirty_params = clean_client_params(dirty_params)
+    dirty_params = calculate_dob(dirty_params)
 
     return append_client_identifier(dirty_params)
+  end
+
+  private def calculate_dob(dirty_params)
+    # Clear the DOB if the client is a youth or the month or year of birth are blank
+    clear_dob = dirty_params[:is_currently_youth] == '1' ||
+      dirty_params[:month_of_birth].blank? ||
+      dirty_params[:year_of_birth].blank?
+    if clear_dob
+      dirty_params[:date_of_birth] = nil
+    else
+      dirty_params[:date_of_birth] = Date.new(dirty_params[:year_of_birth].to_i, dirty_params[:month_of_birth].to_i, 1)
+    end
+    dirty_params.delete(:month_of_birth)
+    dirty_params.delete(:year_of_birth)
+
+    dirty_params
   end
 
   private def import_params

--- a/app/models/concerns/pathways_version_four_calculations.rb
+++ b/app/models/concerns/pathways_version_four_calculations.rb
@@ -53,7 +53,7 @@ module PathwaysVersionFourCalculations
         }
       end
       status = if identified? then 'Identified' else 'Deidentified' end
-      options.map do |k, v|
+      options&.map do |k, v|
         [
           "#{status}#{k}",
           "#{v} - #{status}",

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -10,6 +10,7 @@ class DeidentifiedClient < NonHmisClient
   validates :client_identifier, uniqueness: true
   has_many :client_assessments, class_name: 'DeidentifiedClientAssessment', foreign_key: :non_hmis_client_id, dependent: :destroy
   accepts_nested_attributes_for :client_assessments
+  attr_accessor :month_of_birth, :year_of_birth
 
   scope :visible_to, ->(user) do
     if user.can_edit_all_clients? || user.can_manage_all_deidentified_clients?

--- a/app/views/deidentified_clients/_js.haml
+++ b/app/views/deidentified_clients/_js.haml
@@ -28,7 +28,6 @@
     $('.jFamily').trigger('change');
     $('.jInterestedInSetAsides').trigger('change');
     $('.jIsYouth').on('change', function(e){
-      console.log('jIsYouth changed');
       if($(this).is(':checked')){
         $('.jBirthDate').hide();
       } else {

--- a/app/views/deidentified_clients/_js.haml
+++ b/app/views/deidentified_clients/_js.haml
@@ -27,12 +27,21 @@
     $('.jContact').trigger('change');
     $('.jFamily').trigger('change');
     $('.jInterestedInSetAsides').trigger('change');
+    $('.jIsYouth').on('change', function(e){
+      console.log('jIsYouth changed');
+      if($(this).is(':checked')){
+        $('.jBirthDate').hide();
+      } else {
+        $('.jBirthDate').show();
+      }
+    });
+    $('.jIsYouth').trigger('change');
     $('.jStatusAvailbleTrigger').on('change', function(e){
       if($(this).val() == 'true') {
         $('.jStatusUnavailble input').val('');
         $('.jStatusUnavailble').hide();
-       } else {
-         $('.jStatusUnavailble').show();
+      } else {
+        $('.jStatusUnavailble').show();
       }
     });
     $('.jStatusAvailbleTrigger').trigger('change');

--- a/app/views/deidentified_clients/_pathways_client.haml
+++ b/app/views/deidentified_clients/_pathways_client.haml
@@ -1,15 +1,31 @@
 .row
-  .col-md-6
+  .col-md-12
     .c-question
       - if disabled
         = render 'non_hmis_clients/assessments/question_display', value: @non_hmis_client.client_identifier, label: 'Client Identifier'
       - else
         = form.input :client_identifier, required: true
+    %hr
     .c-question
+      - unless disabled
+        %h3 Age
+        %p As this is a deidentified client, you cannot provide their exact date of birth, however, you can indicate the client is between the ages of 18 and 24 (a youth), or can enter a month and year of birth and the system will calculate the age.
       - if disabled
-        = render 'non_hmis_clients/assessments/question_display', value: @non_hmis_client.is_currently_youth, label: 'Is the client between the ages of 18 and 24?'
+        - if @non_hmis_client.date_of_birth.blank?
+          = render 'non_hmis_clients/assessments/question_display', value: @non_hmis_client.is_currently_youth, label: 'Is the client between the ages of 18 and 24?'
       - else
-        = form.input :is_currently_youth, as: :pretty_boolean, wrapper: :custom_boolean
+        = form.input :is_currently_youth, as: :pretty_boolean, wrapper: :custom_boolean, input_html: { class: 'jIsYouth' }
+    .c-question.jBirthDate
+      - if disabled
+        - if @non_hmis_client.date_of_birth.present? && @non_hmis_client.is_currently_youth.blank?
+          = render 'non_hmis_clients/assessments/question_display', value: @non_hmis_client.age, label: 'Age'
+      - else
+        .row
+          .col-6
+            = form.input :month_of_birth, as: :select_2, collection: (1..12).map { |m| ["#{Date::MONTHNAMES[m]} (#{m})", m] }, selected: @non_hmis_client.date_of_birth&.month, include_blank: true
+          .col-6
+            = form.input :year_of_birth, as: :select_2, collection: (1920..Date.current.year).to_a.reverse, selected: @non_hmis_client.date_of_birth&.year, include_blank: true
+    %hr
     - if Warehouse::Base.enabled?
       .c-question
         - if disabled


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Adds the ability to either specify de-identified clients are "youth" or give a month and year
* Some logic to ensure we only set one of those options

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
