### PR TITLE
Option to set default for elevator access on units based on building attribute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -804,7 +804,6 @@ DEPENDENCIES
   logstop
   loofah
   marcel
-  marginalia
   maxminddb
   memery
   mini_portile2

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class BuildingsController < ApplicationController
   include HasMatchAccessContext
 
@@ -102,37 +104,50 @@ class BuildingsController < ApplicationController
   end
   helper_method :show_confidential_names?
 
-	private
-    def building_scope
-      Building.all
-    end
+  private
 
-    def set_building
-      @building = building_scope.find(params[:id])
-    end
+  def building_scope
+    Building.all
+  end
 
-    def set_show_confidential_names
-      @show_confidential_names = can_view_client_confidentiality? && params[:confidential_override].present?
-    end
+  def set_building
+    @building = building_scope.find(params[:id])
+  end
 
-    def building_params
-      params.require(:building).permit(
-        :name, :building_type, :subgrantee_id, :address, :city, :state, :zip_code,
-        service_ids: [],
-        requirements_attributes: [:id, :rule_id, :positive, :variable, :_destroy]
-      )
-    end
+  def set_show_confidential_names
+    @show_confidential_names = can_view_client_confidentiality? && params[:confidential_override].present?
+  end
 
-    def sort_column
-      Building.column_names.include?(params[:sort]) ? params[:sort] : 'id'
-    end
+  def building_params
+    params.require(:building).permit(
+      :name,
+      :building_type,
+      :subgrantee_id,
+      :address,
+      :city,
+      :state,
+      :zip_code,
+      :elevator_accessible_default,
+      service_ids: [],
+      requirements_attributes: [
+        :id,
+        :rule_id,
+        :positive,
+        :variable,
+        :_destroy,
+      ],
+    )
+  end
 
-    def sort_direction
-      %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
-    end
+  def sort_column
+    Building.column_names.include?(params[:sort]) ? params[:sort] : 'id'
+  end
 
-    def query_string
-      "%#{@query}%"
-    end
+  def sort_direction
+    ['asc', 'desc'].include?(params[:direction]) ? params[:direction] : 'asc'
+  end
 
+  def query_string
+    "%#{@query}%"
+  end
 end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 class UnitsController < ApplicationController
   before_action :authenticate_user!
   before_action :require_can_view_units!

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -44,6 +44,8 @@ class UnitsController < ApplicationController
   def new
     @unit = Unit.new
     set_building
+    @unit.elevator_accessible = @unit.building.elevator_accessible_default
+    set_building
   end
 
   # GET /hmis/units/1/edit

--- a/app/views/buildings/_form.html.haml
+++ b/app/views/buildings/_form.html.haml
@@ -12,6 +12,7 @@
         = f.input :state, disabled: disabled
         = f.input :zip_code, disabled: disabled
         = f.association :subgrantee, label_method: :name, disabled: disabled
+        = f.input :elevator_accessible_default, as: :pretty_boolean, disabled: disabled, label: 'Should all units in this building be elevator accessible or ground floor by default?', hint: 'If checked, any new units will include a checked "Is this unit elevator accessible, or a ground floor unit?" as a default value.'
 
         = render 'service_manager/form_fields', form: f, heading: "Services Attached to this #{Building.model_name.human}"
 

--- a/db/migrate/20250917150302_building_elevator_default.rb
+++ b/db/migrate/20250917150302_building_elevator_default.rb
@@ -1,0 +1,5 @@
+class BuildingElevatorDefault < ActiveRecord::Migration[7.2]
+  def change
+    add_column :buildings, :elevator_accessible_default, :boolean, default: false
+  end
+end

--- a/db/migrate/20250917150302_building_elevator_default.rb
+++ b/db/migrate/20250917150302_building_elevator_default.rb
@@ -1,3 +1,11 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
 class BuildingElevatorDefault < ActiveRecord::Migration[7.2]
   def change
     add_column :buildings, :elevator_accessible_default, :boolean, default: false

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,3 +1,8 @@
+\restrict PDkjFva4oDzc3u4hRjy9hHy6GDfxIURDo0fHEJboI60CULntHbXrehcM7ObEvDz
+
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.6 (Debian 17.6-1.pgdg12+1)
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -9,6 +14,20 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
 
 SET default_tablespace = '';
 
@@ -186,7 +205,8 @@ CREATE TABLE public.buildings (
     city character varying,
     state character varying,
     zip_code character varying,
-    geo_code character varying
+    geo_code character varying,
+    elevator_accessible_default boolean DEFAULT false
 );
 
 
@@ -343,10 +363,10 @@ CREATE TABLE public.client_opportunity_matches (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     deleted_at timestamp without time zone,
+    selected boolean,
     active boolean DEFAULT false NOT NULL,
     closed boolean DEFAULT false NOT NULL,
     closed_reason character varying,
-    selected boolean,
     universe_state json,
     custom_expiration_length integer,
     shelter_expiration date,
@@ -375,6 +395,27 @@ CREATE SEQUENCE public.client_opportunity_matches_id_seq
 --
 
 ALTER SEQUENCE public.client_opportunity_matches_id_seq OWNED BY public.client_opportunity_matches.id;
+
+
+--
+-- Name: client_search_queries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.client_search_queries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    created_by_id bigint NOT NULL,
+    params jsonb NOT NULL,
+    fingerprint character varying NOT NULL
+);
+
+
+--
+-- Name: COLUMN client_search_queries.fingerprint; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.client_search_queries.fingerprint IS 'hash of normalized search parameters used for deduplication and efficient query retrieval';
 
 
 --
@@ -446,8 +487,8 @@ CREATE TABLE public.clients (
     vispdat_priority_score integer DEFAULT 0,
     vispdat_length_homeless_in_days integer DEFAULT 0 NOT NULL,
     cspech_eligible boolean DEFAULT false,
-    alternate_names character varying,
     calculated_last_homeless_night date,
+    alternate_names character varying,
     congregate_housing boolean DEFAULT false,
     sober_housing boolean DEFAULT false,
     enrolled_project_ids jsonb,
@@ -919,8 +960,8 @@ ALTER SEQUENCE public.domestic_violence_survivors_id_seq OWNED BY public.domesti
 CREATE TABLE public.entity_view_permissions (
     id integer NOT NULL,
     user_id integer,
-    entity_id integer NOT NULL,
     entity_type character varying NOT NULL,
+    entity_id integer NOT NULL,
     editable boolean,
     deleted_at timestamp without time zone,
     agency_id bigint
@@ -989,8 +1030,8 @@ CREATE TABLE public.external_referrals (
     client_id bigint NOT NULL,
     user_id bigint NOT NULL,
     referred_on date NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone
 );
 
@@ -1263,8 +1304,8 @@ CREATE TABLE public.housing_attributes (
     name character varying,
     value character varying,
     deleted_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -1298,8 +1339,8 @@ CREATE TABLE public.housing_media_links (
     label character varying,
     url character varying,
     deleted_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -1567,8 +1608,8 @@ CREATE TABLE public.match_decisions (
     deleted_at timestamp without time zone,
     administrative_cancel_reason_id integer,
     administrative_cancel_reason_other_explanation character varying,
-    disable_opportunity boolean DEFAULT false,
     application_date date,
+    disable_opportunity boolean DEFAULT false,
     external_software_used boolean DEFAULT false NOT NULL,
     address character varying,
     include_note_in_email boolean,
@@ -1650,8 +1691,8 @@ CREATE TABLE public.match_mitigation_reasons (
     client_opportunity_match_id bigint,
     mitigation_reason_id bigint,
     addressed boolean DEFAULT false,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -1765,7 +1806,7 @@ CREATE TABLE public.match_routes (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     stalled_interval integer DEFAULT 7 NOT NULL,
-    match_prioritization_id integer DEFAULT 6 NOT NULL,
+    match_prioritization_id integer DEFAULT 7 NOT NULL,
     should_cancel_other_matches boolean DEFAULT true NOT NULL,
     should_activate_match boolean DEFAULT true NOT NULL,
     should_prevent_multiple_matches_per_client boolean DEFAULT true NOT NULL,
@@ -1852,8 +1893,8 @@ CREATE TABLE public.mitigation_reasons (
     id bigint NOT NULL,
     name character varying,
     active boolean DEFAULT true,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -2100,8 +2141,6 @@ CREATE TABLE public.non_hmis_assessments (
     assessment_name character varying,
     hud_assessment_location integer,
     hud_assessment_type integer,
-    staff_name character varying,
-    staff_email character varying,
     enrolled_in_es boolean DEFAULT false NOT NULL,
     enrolled_in_so boolean DEFAULT false NOT NULL,
     additional_homeless_nights_sheltered integer DEFAULT 0,
@@ -2254,7 +2293,7 @@ CREATE TABLE public.non_hmis_clients (
     calculated_chronic_homelessness integer,
     type character varying,
     available boolean DEFAULT true NOT NULL,
-    neighborhood_interests json DEFAULT '[]'::json,
+    neighborhood_interests json DEFAULT '[]'::jsonb,
     income_total_monthly double precision,
     disabling_condition boolean DEFAULT false,
     physical_disability boolean DEFAULT false,
@@ -2424,9 +2463,9 @@ CREATE TABLE public.opportunities (
     updated_at timestamp without time zone NOT NULL,
     deleted_at timestamp without time zone,
     unit_id integer,
+    matchability double precision,
     available_candidate boolean DEFAULT true,
     voucher_id integer,
-    matchability double precision,
     success boolean DEFAULT false
 );
 
@@ -2527,8 +2566,8 @@ CREATE TABLE public.outreach_histories (
     non_hmis_client_id bigint NOT NULL,
     user_id bigint NOT NULL,
     outreach_name character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -2775,8 +2814,8 @@ CREATE TABLE public.project_clients (
     sober_housing boolean DEFAULT false,
     enrolled_project_ids jsonb,
     active_cohort_ids jsonb,
-    vispdat_priority_score integer DEFAULT 0,
     client_identifier character varying,
+    vispdat_priority_score integer DEFAULT 0,
     assessment_score integer DEFAULT 0 NOT NULL,
     ssvf_eligible boolean DEFAULT false NOT NULL,
     rrh_desired boolean DEFAULT false NOT NULL,
@@ -3120,8 +3159,8 @@ ALTER SEQUENCE public.reporting_decisions_id_seq OWNED BY public.reporting_decis
 CREATE TABLE public.requirements (
     id integer NOT NULL,
     rule_id integer,
-    requirer_id integer,
     requirer_type character varying,
+    requirer_id integer,
     positive boolean,
     deleted_at timestamp without time zone,
     created_at timestamp without time zone,
@@ -3161,9 +3200,12 @@ CREATE TABLE public.roles (
     updated_at timestamp without time zone NOT NULL,
     can_view_all_clients boolean DEFAULT false,
     can_edit_all_clients boolean DEFAULT false,
+    can_edit_clients_based_on_rules boolean DEFAULT false,
     can_participate_in_matches boolean DEFAULT false,
     can_view_all_matches boolean DEFAULT false,
+    can_view_own_closed_matches boolean DEFAULT false,
     can_see_alternate_matches boolean DEFAULT false,
+    can_see_all_alternate_matches boolean DEFAULT false,
     can_edit_match_contacts boolean DEFAULT false,
     can_approve_matches boolean DEFAULT false,
     can_reject_matches boolean DEFAULT false,
@@ -3173,6 +3215,11 @@ CREATE TABLE public.roles (
     can_edit_users boolean DEFAULT false,
     can_view_full_ssn boolean DEFAULT false,
     can_view_full_dob boolean DEFAULT false,
+    can_view_dmh_eligibility boolean DEFAULT false,
+    can_view_va_eligibility boolean DEFAULT false,
+    can_view_hues_eligibility boolean DEFAULT false,
+    can_view_hiv_positive_eligibility boolean DEFAULT false,
+    can_view_client_confidentiality boolean DEFAULT false,
     can_view_buildings boolean DEFAULT false,
     can_edit_buildings boolean DEFAULT false,
     can_view_funding_sources boolean DEFAULT false,
@@ -3182,7 +3229,10 @@ CREATE TABLE public.roles (
     can_view_vouchers boolean DEFAULT false,
     can_edit_vouchers boolean DEFAULT false,
     can_view_programs boolean DEFAULT false,
+    can_view_assigned_programs boolean DEFAULT false,
     can_edit_programs boolean DEFAULT false,
+    can_edit_assigned_programs boolean DEFAULT false,
+    can_edit_voucher_rules boolean DEFAULT false,
     can_view_opportunities boolean DEFAULT false,
     can_edit_opportunities boolean DEFAULT false,
     can_reissue_notifications boolean DEFAULT false,
@@ -3197,44 +3247,33 @@ CREATE TABLE public.roles (
     can_edit_available_services boolean DEFAULT false,
     can_assign_services boolean DEFAULT false,
     can_assign_requirements boolean DEFAULT false,
-    can_view_dmh_eligibility boolean DEFAULT false,
-    can_view_va_eligibility boolean DEFAULT false NOT NULL,
-    can_view_hues_eligibility boolean DEFAULT false NOT NULL,
     can_become_other_users boolean DEFAULT false,
-    can_view_client_confidentiality boolean DEFAULT false NOT NULL,
-    can_view_hiv_positive_eligibility boolean DEFAULT false,
-    can_view_own_closed_matches boolean DEFAULT false,
     can_edit_translations boolean DEFAULT false,
     can_view_vspdats boolean DEFAULT false,
     can_manage_config boolean DEFAULT false,
     can_create_overall_note boolean DEFAULT false,
+    can_delete_client_notes boolean DEFAULT false,
     can_enter_deidentified_clients boolean DEFAULT false,
     can_manage_deidentified_clients boolean DEFAULT false,
+    can_manage_all_deidentified_clients boolean DEFAULT false,
+    can_export_deidentified_clients boolean DEFAULT false,
     can_add_cohorts_to_deidentified_clients boolean DEFAULT false,
-    can_delete_client_notes boolean DEFAULT false,
     can_enter_identified_clients boolean DEFAULT false,
     can_manage_identified_clients boolean DEFAULT false,
+    can_manage_all_identified_clients boolean DEFAULT false,
+    can_export_identified_clients boolean DEFAULT false,
+    can_view_all_covid_pathways boolean DEFAULT false,
     can_add_cohorts_to_identified_clients boolean DEFAULT false,
     can_manage_neighborhoods boolean DEFAULT false,
-    can_view_assigned_programs boolean DEFAULT false,
-    can_edit_assigned_programs boolean DEFAULT false,
-    can_export_deidentified_clients boolean DEFAULT false,
-    can_export_identified_clients boolean DEFAULT false,
     can_manage_tags boolean DEFAULT false,
     can_manage_imported_clients boolean DEFAULT false,
-    can_edit_clients_based_on_rules boolean DEFAULT false,
     can_send_notes_via_email boolean DEFAULT false,
     can_upload_deidentified_clients boolean DEFAULT false,
     can_delete_matches boolean DEFAULT false,
     can_reopen_matches boolean DEFAULT false,
-    can_see_all_alternate_matches boolean DEFAULT false,
     can_edit_help boolean DEFAULT false,
     can_audit_users boolean DEFAULT false,
-    can_view_all_covid_pathways boolean DEFAULT false,
     can_manage_sessions boolean DEFAULT false,
-    can_edit_voucher_rules boolean DEFAULT false,
-    can_manage_all_deidentified_clients boolean DEFAULT false,
-    can_manage_all_identified_clients boolean DEFAULT false,
     can_activate_matches boolean DEFAULT false
 );
 
@@ -3413,8 +3452,8 @@ CREATE TABLE public.shelter_histories (
     non_hmis_client_id bigint NOT NULL,
     user_id bigint NOT NULL,
     shelter_name character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -3513,8 +3552,8 @@ CREATE TABLE public.sub_program_contacts (
     id bigint NOT NULL,
     sub_program_id bigint NOT NULL,
     contact_id bigint NOT NULL,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone,
     dnd_staff boolean DEFAULT false NOT NULL,
     housing_subsidy_admin boolean DEFAULT false NOT NULL,
@@ -3985,8 +4024,8 @@ CREATE TABLE public.users (
     invitation_sent_at timestamp without time zone,
     invitation_accepted_at timestamp without time zone,
     invitation_limit integer,
-    invited_by_id integer,
     invited_by_type character varying,
+    invited_by_id integer,
     invitations_count integer DEFAULT 0,
     receive_initial_notification boolean DEFAULT false,
     first_name character varying,
@@ -4147,8 +4186,8 @@ CREATE TABLE public.weighting_rules (
     route_id bigint,
     requirement_id bigint,
     applied_to integer DEFAULT 0,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
     deleted_at timestamp without time zone
 );
 
@@ -4894,6 +4933,14 @@ ALTER TABLE ONLY public.client_opportunity_match_contacts
 
 ALTER TABLE ONLY public.client_opportunity_matches
     ADD CONSTRAINT client_opportunity_matches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: client_search_queries client_search_queries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.client_search_queries
+    ADD CONSTRAINT client_search_queries_pkey PRIMARY KEY (id);
 
 
 --
@@ -6724,148 +6771,159 @@ CREATE INDEX index_weighting_rules_on_route_id ON public.weighting_rules USING b
 
 
 --
--- Name: non_hmis_assessments non_hmis_assessments_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: uidx_client_search_queries; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX uidx_client_search_queries ON public.client_search_queries USING btree (fingerprint);
+
+
+--
+-- Name: sub_programs fk_rails_08099961f4; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sub_programs
+    ADD CONSTRAINT fk_rails_08099961f4 FOREIGN KEY (program_id) REFERENCES public.programs(id);
+
+
+--
+-- Name: sub_programs fk_rails_1c9726a2f9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sub_programs
+    ADD CONSTRAINT fk_rails_1c9726a2f9 FOREIGN KEY (hsa_id) REFERENCES public.subgrantees(id);
+
+
+--
+-- Name: non_hmis_assessments fk_rails_2ebe7e2474; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.non_hmis_assessments
-    ADD CONSTRAINT non_hmis_assessments_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT fk_rails_2ebe7e2474 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
--- Name: opportunities opportunities_voucher_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: user_roles fk_rails_318345354e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_roles
+    ADD CONSTRAINT fk_rails_318345354e FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_roles fk_rails_3369e0d5fc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_roles
+    ADD CONSTRAINT fk_rails_3369e0d5fc FOREIGN KEY (role_id) REFERENCES public.roles(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vouchers fk_rails_3938619bb0; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vouchers
+    ADD CONSTRAINT fk_rails_3938619bb0 FOREIGN KEY (sub_program_id) REFERENCES public.sub_programs(id);
+
+
+--
+-- Name: vouchers fk_rails_3e6ca7b204; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vouchers
+    ADD CONSTRAINT fk_rails_3e6ca7b204 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: reissue_requests fk_rails_5502b5ba7e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reissue_requests
+    ADD CONSTRAINT fk_rails_5502b5ba7e FOREIGN KEY (reissued_by) REFERENCES public.users(id);
+
+
+--
+-- Name: programs fk_rails_6a0a1e6411; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.programs
+    ADD CONSTRAINT fk_rails_6a0a1e6411 FOREIGN KEY (subgrantee_id) REFERENCES public.subgrantees(id);
+
+
+--
+-- Name: sub_programs fk_rails_7aa5978182; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sub_programs
+    ADD CONSTRAINT fk_rails_7aa5978182 FOREIGN KEY (building_id) REFERENCES public.buildings(id);
+
+
+--
+-- Name: reissue_requests fk_rails_7f153cde04; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reissue_requests
+    ADD CONSTRAINT fk_rails_7f153cde04 FOREIGN KEY (notification_id) REFERENCES public.notifications(id);
+
+
+--
+-- Name: opportunities fk_rails_90139b441c; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.opportunities
-    ADD CONSTRAINT opportunities_voucher_id_fkey FOREIGN KEY (voucher_id) REFERENCES public.vouchers(id);
+    ADD CONSTRAINT fk_rails_90139b441c FOREIGN KEY (voucher_id) REFERENCES public.vouchers(id);
 
 
 --
--- Name: programs programs_contact_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.programs
-    ADD CONSTRAINT programs_contact_id_fkey FOREIGN KEY (contact_id) REFERENCES public.contacts(id);
-
-
---
--- Name: programs programs_funding_source_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: programs fk_rails_9d29596bf8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.programs
-    ADD CONSTRAINT programs_funding_source_id_fkey FOREIGN KEY (funding_source_id) REFERENCES public.funding_sources(id);
+    ADD CONSTRAINT fk_rails_9d29596bf8 FOREIGN KEY (funding_source_id) REFERENCES public.funding_sources(id);
 
 
 --
--- Name: programs programs_subgrantee_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: vouchers fk_rails_b7b36b70ab; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.vouchers
+    ADD CONSTRAINT fk_rails_b7b36b70ab FOREIGN KEY (unit_id) REFERENCES public.units(id);
+
+
+--
+-- Name: sub_programs fk_rails_b8163bf251; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sub_programs
+    ADD CONSTRAINT fk_rails_b8163bf251 FOREIGN KEY (subgrantee_id) REFERENCES public.subgrantees(id);
+
+
+--
+-- Name: programs fk_rails_c0d5ae3683; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.programs
-    ADD CONSTRAINT programs_subgrantee_id_fkey FOREIGN KEY (subgrantee_id) REFERENCES public.subgrantees(id);
+    ADD CONSTRAINT fk_rails_c0d5ae3683 FOREIGN KEY (contact_id) REFERENCES public.contacts(id);
 
 
 --
--- Name: reissue_requests reissue_requests_notification_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reissue_requests
-    ADD CONSTRAINT reissue_requests_notification_id_fkey FOREIGN KEY (notification_id) REFERENCES public.notifications(id);
-
-
---
--- Name: reissue_requests reissue_requests_reissued_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reissue_requests
-    ADD CONSTRAINT reissue_requests_reissued_by_fkey FOREIGN KEY (reissued_by) REFERENCES public.users(id);
-
-
---
--- Name: sub_programs sub_programs_building_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: sub_programs fk_rails_f92c6a12a3; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.sub_programs
-    ADD CONSTRAINT sub_programs_building_id_fkey FOREIGN KEY (building_id) REFERENCES public.buildings(id);
-
-
---
--- Name: sub_programs sub_programs_hsa_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sub_programs
-    ADD CONSTRAINT sub_programs_hsa_id_fkey FOREIGN KEY (hsa_id) REFERENCES public.subgrantees(id);
-
-
---
--- Name: sub_programs sub_programs_program_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sub_programs
-    ADD CONSTRAINT sub_programs_program_id_fkey FOREIGN KEY (program_id) REFERENCES public.programs(id);
-
-
---
--- Name: sub_programs sub_programs_sub_contractor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sub_programs
-    ADD CONSTRAINT sub_programs_sub_contractor_id_fkey FOREIGN KEY (sub_contractor_id) REFERENCES public.subgrantees(id);
-
-
---
--- Name: sub_programs sub_programs_subgrantee_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sub_programs
-    ADD CONSTRAINT sub_programs_subgrantee_id_fkey FOREIGN KEY (subgrantee_id) REFERENCES public.subgrantees(id);
-
-
---
--- Name: user_roles user_roles_role_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.user_roles
-    ADD CONSTRAINT user_roles_role_id_fkey FOREIGN KEY (role_id) REFERENCES public.roles(id) ON DELETE CASCADE;
-
-
---
--- Name: user_roles user_roles_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.user_roles
-    ADD CONSTRAINT user_roles_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
-
-
---
--- Name: vouchers vouchers_sub_program_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vouchers
-    ADD CONSTRAINT vouchers_sub_program_id_fkey FOREIGN KEY (sub_program_id) REFERENCES public.sub_programs(id);
-
-
---
--- Name: vouchers vouchers_unit_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vouchers
-    ADD CONSTRAINT vouchers_unit_id_fkey FOREIGN KEY (unit_id) REFERENCES public.units(id);
-
-
---
--- Name: vouchers vouchers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.vouchers
-    ADD CONSTRAINT vouchers_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT fk_rails_f92c6a12a3 FOREIGN KEY (sub_contractor_id) REFERENCES public.subgrantees(id);
 
 
 --
 -- PostgreSQL database dump complete
 --
 
+\unrestrict PDkjFva4oDzc3u4hRjy9hHy6GDfxIURDo0fHEJboI60CULntHbXrehcM7ObEvDz
+
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250917150302'),
+('20250821213202'),
 ('20250716125401'),
 ('20250319145924'),
 ('20250208210918'),
@@ -6960,7 +7018,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211129191957'),
 ('20211129190937'),
 ('20211122204003'),
-('20211115133847'),
 ('20211027170803'),
 ('20211027134707'),
 ('20211020150747'),
@@ -7212,8 +7269,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20170605162924'),
 ('20170524180812'),
 ('20170524180811'),
-('20170524180728'),
-('20170524180727'),
 ('20170511194721'),
 ('20170511192828'),
 ('20170505170358'),


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Adds the ability to set a default at the building level for if newly added units should be considered ground floor or elevator accessible.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail