### PR TITLE
Require notes for all decline reasons on routes 1, 2, 3, 11, and 13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,7 @@ GEM
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (4.0.1)
+      rack (>= 1.2.0)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)

--- a/app/models/concerns/match_decisions/accepts_decline_reason.rb
+++ b/app/models/concerns/match_decisions/accepts_decline_reason.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   module AcceptsDeclineReason
     extend ActiveSupport::Concern
@@ -13,20 +15,35 @@ module MatchDecisions
     end
 
     def decline_reasons(contact:)
-      @_decline_reasons ||= [].tap do |result| # rubocop:disable Naming/MemoizedInstanceVariableName
+      @decline_reasons ||= [].tap do |result|
         MatchDecisionReasons::Base.active.where(name: step_decline_reasons(contact)).find_each do |reason|
           result << reason
         end
         # Move other to the end of the list
         result.sort_by! { |m| [m.name.downcase == 'other' ? 1 : 0, m.name.downcase] }
         result.map! do |reason|
-          # Only include the asterisks if more than 'Other' requires additional explanation
-          include_asterisk = decline_reasons_not_other_requiring_explanation.present? && (reason.other? || decline_reasons_not_other_requiring_explanation.include?(reason.name))
+          # Only include the asterisks if more than 'Other' requires additional explanation && if not ALL decline reasons require additional explanation
+          not_other = decline_reasons_not_other_requiring_explanation(contact)
+          more_than_other_requires_explanation = not_other.present?
+          this_reason_requires_explanation = not_other.include?(reason.name)
+
+          include_asterisk = if all_declines_require_explanation(contact)
+            false
+          elsif more_than_other_requires_explanation && (reason.other? || this_reason_requires_explanation)
+            true
+          end
+
           name = reason.name
           name += '*' if include_asterisk
           [name, reason.id]
         end
       end
+    end
+
+    def all_declines_require_explanation(contact)
+      not_other = decline_reasons_not_other_requiring_explanation(contact)
+      step_reasons_except_other = step_decline_reasons(contact).reject { |r| r == 'Other' }
+      not_other.sort == step_reasons_except_other.sort
     end
 
     def whitelist_params_for_update params

--- a/app/models/concerns/match_decisions/route_eleven_decline_reasons.rb
+++ b/app/models/concerns/match_decisions/route_eleven_decline_reasons.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   module RouteElevenDeclineReasons
     extend ActiveSupport::Concern
@@ -21,6 +23,10 @@ module MatchDecisions
         'Client deceased',
         'Other',
       ]
+    end
+
+    def decline_reasons_not_other_requiring_explanation(contact = nil)
+      step_decline_reasons(contact).reject { |reason| reason == 'Other' }
     end
   end
 end

--- a/app/models/concerns/match_decisions/route_one_decline_reasons.rb
+++ b/app/models/concerns/match_decisions/route_one_decline_reasons.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module MatchDecisions
+  module RouteOneDeclineReasons
+    extend ActiveSupport::Concern
+
+    def decline_reasons_not_other_requiring_explanation(contact = nil)
+      step_decline_reasons(contact).reject { |reason| reason == 'Other' }
+    end
+  end
+end

--- a/app/models/concerns/match_decisions/route_thirteen_decline_reasons.rb
+++ b/app/models/concerns/match_decisions/route_thirteen_decline_reasons.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   module RouteThirteenDeclineReasons
     extend ActiveSupport::Concern
@@ -31,11 +33,8 @@ module MatchDecisions
       ]
     end
 
-    def decline_reasons_not_other_requiring_explanation
-      [
-        'Ineligible for Housing Program',
-        'Additional screening criteria imposed by third parties',
-      ]
+    def decline_reasons_not_other_requiring_explanation(contact = nil)
+      step_decline_reasons(contact).reject { |reason| reason == 'Other' }
     end
   end
 end

--- a/app/models/concerns/match_decisions/route_three_decline_reasons.rb
+++ b/app/models/concerns/match_decisions/route_three_decline_reasons.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module MatchDecisions
+  module RouteThreeDeclineReasons
+    extend ActiveSupport::Concern
+
+    def decline_reasons_not_other_requiring_explanation(contact = nil)
+      step_decline_reasons(contact).reject { |reason| reason == 'Other' }
+    end
+  end
+end

--- a/app/models/concerns/match_decisions/route_two_decline_reasons.rb
+++ b/app/models/concerns/match_decisions/route_two_decline_reasons.rb
@@ -1,0 +1,17 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module MatchDecisions
+  module RouteTwoDeclineReasons
+    extend ActiveSupport::Concern
+
+    def decline_reasons_not_other_requiring_explanation(contact = nil)
+      step_decline_reasons(contact).reject { |reason| reason == 'Other' }
+    end
+  end
+end

--- a/app/models/match_decisions/approve_match_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/approve_match_housing_subsidy_admin.rb
@@ -4,9 +4,12 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   class ApproveMatchHousingSubsidyAdmin < Base
     include MatchDecisions::AcceptsDeclineReason
+    include MatchDecisions::RouteOneDeclineReasons
 
     # validate :note_present_if_status_declined
 

--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -489,7 +489,7 @@ module MatchDecisions
       end
     end
 
-    def decline_reasons_not_other_requiring_explanation
+    def decline_reasons_not_other_requiring_explanation(_contact = nil)
       []
     end
 

--- a/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
+++ b/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
@@ -10,6 +10,7 @@ module MatchDecisions::HomelessSetAside
   class SetAsidesHsaAcceptsClient < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
     include MatchDecisions::DefaultSetAsidesDeclineReasons
+    include MatchDecisions::RouteThreeDeclineReasons
 
     # validate :note_present_if_status_declined
     validate :ensure_required_contacts_present_on_accept

--- a/app/models/match_decisions/homeless_set_aside/set_asides_record_client_housed_date_or_decline_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/homeless_set_aside/set_asides_record_client_housed_date_or_decline_housing_subsidy_administrator.rb
@@ -4,10 +4,13 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::HomelessSetAside
   class SetAsidesRecordClientHousedDateOrDeclineHousingSubsidyAdministrator < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
     include MatchDecisions::DefaultSetAsidesDeclineReasons
+    include MatchDecisions::RouteThreeDeclineReasons
 
     attr_accessor :building_id
     attr_accessor :unit_id

--- a/app/models/match_decisions/match_recommendation_shelter_agency.rb
+++ b/app/models/match_decisions/match_recommendation_shelter_agency.rb
@@ -4,10 +4,13 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   class MatchRecommendationShelterAgency < Base
     include MatchDecisions::AcceptsDeclineReason
     include MatchDecisions::DefaultShelterAgencyDeclineReasons
+    include MatchDecisions::RouteOneDeclineReasons
     include MatchDecisions::AcceptsNotWorkingWithClientReason
 
     # proxy for client.release_of_information

--- a/app/models/match_decisions/provider_only/hsa_accepts_client.rb
+++ b/app/models/match_decisions/provider_only/hsa_accepts_client.rb
@@ -12,6 +12,7 @@ module MatchDecisions::ProviderOnly
       'match_decisions/hsa_accepts_client'
     end
     include MatchDecisions::AcceptsDeclineReason
+    include MatchDecisions::RouteTwoDeclineReasons
 
     attr_accessor :building_id
     attr_accessor :unit_id

--- a/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
@@ -4,9 +4,12 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions
   class ScheduleCriminalHearingHousingSubsidyAdmin < Base
     include MatchDecisions::AcceptsDeclineReason # For shelter agency declines
+    include MatchDecisions::RouteOneDeclineReasons
 
     validate :criminal_hearing_date_present_if_scheduled
     validate :criminal_hearing_date_absent_if_no_hearing

--- a/app/views/match_decisions/_decline_reason.haml
+++ b/app/views/match_decisions/_decline_reason.haml
@@ -2,10 +2,18 @@
 - include_other = true unless include_other === false
 
 = form.association :decline_reason, collection: @decision.decline_reasons(contact: current_contact), label: "Please indicate a reason to #{client_action} this match:", as: :check_boxes, wrapper_html: {class: 'jDeclineReasons jButtonStateTriggers'}
-- if @decision.decline_reasons_not_other_requiring_explanation.present?
+
+- if @decision.decline_reasons_not_other_requiring_explanation(current_contact).present? && !@decision.all_declines_require_explanation(current_contact)
   %p= "* indicates that additional information must be provided in order to submit #{client_action} reason"
 - if include_other
-  = form.input :decline_reason_other_explanation, as: :text, label: "List any details related to the #{client_action} below", hint: 'Required for "Other"', placeholder: 'Other reason', input_html: {rows: 8}, wrapper_html: {class: 'jOtherDeclineReason'}
+  - label = "List any details related to the #{client_action} below"
+  - hint = 'Required for "Other"'
+  - placeholder = 'Other reason'
+  - if @decision.all_declines_require_explanation(current_contact)
+    - label = "In addition to the reason selected above, please provide additional detail related to the reason as to why the client is declining or being declined this resource"
+    - hint = 'Required for all decline reasons'
+    - placeholder = 'Additional details'
+  = form.input :decline_reason_other_explanation, as: :text, label: label, hint: hint, placeholder: placeholder, input_html: {rows: 8}, wrapper_html: {class: 'jOtherDeclineReason'}
 
 = content_for :page_js do
   :javascript

--- a/app/views/matches/_client_files.haml
+++ b/app/views/matches/_client_files.haml
@@ -1,5 +1,5 @@
 - client = match.client
-- file_ids = @files.values.map(&:last).map(&:presence).compact.map(&:id).join(',')
+- file_ids = @files&.values&.map(&:last)&.map(&:presence)&.compact&.map(&:id)&.join(',')
 - url = Config.get(:warehouse_url) + "/clients/#{client.remote_id}/files"
 - if file_ids.present?
   - url += "?file_ids=#{file_ids}"
@@ -7,7 +7,7 @@
 .detail-box--value
   - if @show_files
     -# Show the most recent version of any matching files
-    - @files.each do |tag, (required, source, file)|
+    - @files&.each do |tag, (required, source, file)|
       .file
         - if required
           *

--- a/spec/models/rules/pathways_eligible_spec.rb
+++ b/spec/models/rules/pathways_eligible_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Rules::PathwaysEligible, type: :model do
         roy_match.program.update(match_route_id: MatchRoutes::ProviderOnly.first.id)
         bob_match.program.update(match_route_id: MatchRoutes::ProviderOnly.first.id)
         decision = roy.client_opportunity_matches.first.hsa_accepts_client_decision
-        decision.update(decline_reason_id: hsa_decline_reason.id, status: :declined)
+        decision.update!(decline_reason_id: hsa_decline_reason.id, status: :declined, decline_reason_other_explanation: 'test')
       end
 
       context 'when positive' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Extends the ability to enforce notes for decline reasons to more routes
* Specifies that all declines on routes 1, 2, 3, 11, and 13 require reasons
* Adjusts language around data collection of reasons for the situation where all choices require a note

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
