### PR TITLE
Simplify error message when all decline reasons are required

### DIFF
--- a/app/models/concerns/match_decisions/accepts_decline_reason.rb
+++ b/app/models/concerns/match_decisions/accepts_decline_reason.rb
@@ -64,7 +64,8 @@ module MatchDecisions
 
       return unless explanation_field_required && decline_reason_other_explanation.blank?
 
-      if all_declines_require_explanation(contact)
+      # Current contact is unknown in this context
+      if all_declines_require_explanation(nil)
         errors.add :base, 'Decline reason details must be provided for the selection of any decline reason'
       else
         errors.add :decline_reason_other_explanation, "must be filled in if choosing '#{decline_reason&.name}'"

--- a/app/models/concerns/match_decisions/accepts_decline_reason.rb
+++ b/app/models/concerns/match_decisions/accepts_decline_reason.rb
@@ -57,11 +57,18 @@ module MatchDecisions
     end
 
     private def validate_decline_reason
-      errors.add :decline_reason, 'please indicate the reason for declining' if status == 'declined' && decline_reason_blank? || (status == 'shelter_declined' && decline_reason_other_explanation.blank?)
+      errors.add :decline_reason, ' is required when declining a match, please indicate the reason for declining' if status == 'declined' && decline_reason_blank? || (status == 'shelter_declined' && decline_reason_other_explanation.blank?)
 
       explanation_field_required = status == 'declined' && (decline_reason&.other? || decline_reasons_not_other_requiring_explanation&.include?(decline_reason&.name))
       explanation_field_required ||= status == 'shelter_declined' && (decline_reason&.other? || decline_reasons_not_other_requiring_explanation&.include?(decline_reason&.name))
-      errors.add :decline_reason_other_explanation, "must be filled in if choosing '#{decline_reason&.name}'" if explanation_field_required && decline_reason_other_explanation.blank?
+
+      return unless explanation_field_required && decline_reason_other_explanation.blank?
+
+      if all_declines_require_explanation(contact)
+        errors.add :base, 'Decline reason details must be provided for the selection of any decline reason'
+      else
+        errors.add :decline_reason_other_explanation, "must be filled in if choosing '#{decline_reason&.name}'"
+      end
     end
 
     private def decline_reason_blank?


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Updates the decline reason error message to be generic if all decline reasons require a note

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have provided testing instructions in this PR or the related issue (or not applicable)
