### PR TITLE
Affordance for location specific notes on rules

### DIFF
--- a/app/assets/javascripts/requirement_manager/searcher.js.coffee
+++ b/app/assets/javascripts/requirement_manager/searcher.js.coffee
@@ -25,12 +25,15 @@ class App.RequirementManager.Searcher
 
   _init_select_listener: ->
     $(".jVariableRequirment").hide()
+    $(".jRuleSelectionNote").hide()
     $(@element).on 'select2:select', (e) =>
       rule_id = $(@element).val()
       $(".jVariableRequirment").hide()
+      $(".jRuleSelectionNote").hide()
       $(".jVariableRequirment[data-rule-id=#{rule_id}]").show()
       $(".jVariableRequirment[data-rule-id=#{rule_id}] select").css('width', '100%')
       $(".jVariableRequirment[data-rule-id=#{rule_id}] select").select2()
+      $(".jRuleSelectionNote[data-rule-id=#{rule_id}]").show()
 
   reset: ->
     # resetting select2 this way currently throws

--- a/app/assets/stylesheets/application.scss.erb
+++ b/app/assets/stylesheets/application.scss.erb
@@ -105,6 +105,7 @@
 @import "modules/tables";
 @import "modules/vouchers";
 @import "modules/add_things_boxes";
+@import "modules/requirement_manager";
 @import "modules/clients";
 @import "modules/filter_sort";
 @import "modules/_match_list";

--- a/app/assets/stylesheets/modules/_requirement_manager.scss
+++ b/app/assets/stylesheets/modules/_requirement_manager.scss
@@ -1,0 +1,3 @@
+.jRuleSelectionNote.alert p {
+  display: block;
+}

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -43,7 +43,7 @@ class Rule < ApplicationRecord
     ''
   end
 
-  def selection_note(_context: nil)
+  def selection_note(context: nil) # rubocop:disable Lint/UnusedMethodArgument
     nil
   end
 

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -43,6 +43,10 @@ class Rule < ApplicationRecord
     ''
   end
 
+  def selection_note(_context: nil)
+    nil
+  end
+
   def variable_requirement?
     false
   end

--- a/app/models/rules/bedroom.rb
+++ b/app/models/rules/bedroom.rb
@@ -11,6 +11,20 @@ class Rules::Bedroom < Rule
     'Matches clients who require at least the number of bedrooms specified in "Minimum number of bedrooms required" as indicated on an assessment.'
   end
 
+  # supports markdown
+  def selection_note(context: nil)
+    return unless context == :voucher
+
+    # Note for the voucher requirements page, which appears to be have in the reverse of the expected logic.
+    note = <<~NOTE
+      ### Note
+      If this voucher is attached to a 2 bedroom unit, to match a client who requires 2 or more bedrooms, choose "Can't have minimum number of bedrooms" with "One" selected as the number of bedrooms.
+
+      For a 3 bedroom unit, choose"Can't have minimum number of bedrooms" with "Two".
+    NOTE
+    Translation.translate(note)
+  end
+
   def variable_requirement?
     true
   end

--- a/app/models/rules/bedroom.rb
+++ b/app/models/rules/bedroom.rb
@@ -20,7 +20,7 @@ class Rules::Bedroom < Rule
       ### Note
       If this voucher is attached to a 2 bedroom unit, to match a client who requires 2 or more bedrooms, choose "Can't have minimum number of bedrooms" with "One" selected as the number of bedrooms.
 
-      For a 3 bedroom unit, choose"Can't have minimum number of bedrooms" with "Two".
+      For a 3 bedroom unit, choose "Can't have minimum number of bedrooms" with "Two" selected as the number of bedrooms.
     NOTE
     Translation.translate(note)
   end

--- a/app/views/admin/translation_keys/index.html.haml
+++ b/app/views/admin/translation_keys/index.html.haml
@@ -18,7 +18,7 @@
                 %td= translation.key
                 %td
                   = simple_form_for(translation, remote: true, url: admin_translation_text_path(translation.id), method: :patch, html: {class: 'jTranslationTextForm'})do |t|
-                    = t.input :text, label: false, input_html: {class: 'jTranslationText', rows: 2, cols: 30}
+                    = t.input :text, as: :text, label: false, input_html: {class: 'jTranslationText', rows: 4, cols: 30}
                 %td
                   %button.btn.btn-secondary.btn-sm
                     Save

--- a/app/views/requirement_manager/_form_fields.haml
+++ b/app/views/requirement_manager/_form_fields.haml
@@ -2,6 +2,8 @@
 - hide_inherited ||= false
 - on_unit ||= false
 - section_header ||= 'Rules'
+- note_context ||= nil
+- markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true)
 
 .row
   .col-lg-12
@@ -37,6 +39,10 @@
                 - if rule.variable_requirement?
                   .jVariableRequirment.mb-4{data: {rule_id: rule.id}}
                     = render rule
+                - if rule.selection_note(context: note_context).present?
+                  .jRuleSelectionNote.alert.alert-info.mb-4{data: {rule_id: rule.id}, style: 'display: none;'}
+                    .d-block
+                      = markdown.render(rule.selection_note(context: note_context)).html_safe
 
             -# Include jVariableRequirment divs for the existing requirements, otherwise we don't have values if the rule needs to be changed
             - requirements&.each do |requirement|

--- a/app/views/vouchers/edit.haml
+++ b/app/views/vouchers/edit.haml
@@ -4,7 +4,7 @@
 %div{style: 'margin-bottom: 8em;'}
   = simple_form_for(@voucher, url: program_sub_program_voucher_path(@program, @subprogram, @voucher)) do |f|
     = f.error_notification
-    = render 'requirement_manager/form_fields', form: f, selected_requirements_heading: 'Rules for this Voucher', hide_inherited: true
+    = render 'requirement_manager/form_fields', form: f, selected_requirements_heading: 'Rules for this Voucher', hide_inherited: true, note_context: :voucher
 
     .form-actions
       = f.button :submit

--- a/docs/features/requirements_manager.md
+++ b/docs/features/requirements_manager.md
@@ -1,0 +1,174 @@
+# Requirements Manager
+
+The Requirements Manager is a JavaScript-driven UI component that allows administrators to add, remove, and configure rules on various entities in the CAS system. Rules define eligibility criteria for matching clients to housing opportunities.
+
+## Overview
+
+Rules are conditions that can be applied to vouchers, programs, sub-programs, buildings, units, funding sources, and other entities. When a rule is added as a requirement, it can be set as either:
+- **Must** (positive): Client must meet this criterion
+- **Can't** (negative): Client must NOT meet this criterion
+
+## Architecture
+
+### Database Layer
+
+#### Rules Table (`rules`)
+Stores the rule definitions. Each rule has:
+- `type`: STI column pointing to the rule class (e.g., `Rules::Bedroom`)
+- `name`: Display name (e.g., "Minimum number of bedrooms")
+- `alternate_name`: Optional alternate display name for specific contexts
+- `verb`: The verb used in display (e.g., "have", "be")
+
+#### Requirements Table (`requirements`)
+Join table that associates rules with entities:
+- `rule_id`: Reference to the rule
+- `requirer_type` / `requirer_id`: Polymorphic reference to the entity (Voucher, Program, etc.)
+- `positive`: Boolean indicating "Must" (true) or "Can't" (false)
+- `variable`: Optional value for variable rules (e.g., number of bedrooms)
+
+### Rule Classes
+
+Located in `app/models/rules/`, each rule is a subclass of `Rule` (`app/models/rule.rb`).
+
+#### Base Rule Class Methods
+
+| Method | Purpose |
+|--------|---------|
+| `description` | Human-readable explanation of what the rule does |
+| `selection_note(context:)` | Context-specific notes shown when rule is selected in UI |
+| `variable_requirement?` | Returns `true` if the rule requires additional input |
+| `display_for_variable(value)` | Formats the variable value for display |
+| `clients_that_fit(scope, requirement, opportunity)` | Returns clients matching this rule |
+
+#### Variable Rules
+
+Some rules require additional input (e.g., number of bedrooms, income amount). These rules:
+1. Override `variable_requirement?` to return `true`
+2. Provide methods like `available_number_of_bedrooms` to list options
+3. Have a corresponding view partial in `app/views/rules/<rule_name>/`
+
+Example: `Rules::Bedroom` allows selecting 1-5 bedrooms.
+
+### Seeding Rules
+
+Rules are defined in `db/rules.csv` and seeded via rake task:
+
+```bash
+rake cas_seeds:create_rules
+```
+
+**CSV Format:**
+```csv
+Class Name,Rule Name,Alternate Name,Verb
+Bedroom,Minimum number of bedrooms,Fit in bedrooms,have
+ChronicallyHomeless,Chronically Homeless as defined by HUD,,be
+```
+
+The seeder (`app/models/cas_seeds/rules.rb`):
+1. Reads `db/rules.csv`
+2. Creates or updates rules based on `Class Name`
+3. Removes rules not in the CSV (and their associated requirements)
+
+### Adding a New Rule
+
+1. Add entry to `db/rules.csv`
+2. Create rule class in `app/models/rules/your_rule.rb`:
+
+```ruby
+class Rules::YourRule < Rule
+  def description
+    'Description of what this rule matches'
+  end
+
+  def clients_that_fit(scope, requirement, _opportunity)
+    if requirement.positive
+      scope.where(your_condition: true)
+    else
+      scope.where(your_condition: false)
+    end
+  end
+end
+```
+
+3. Run `rake cas_seeds:create_rules`
+
+For variable rules, also:
+- Override `variable_requirement?` to return `true`
+- Create view partial at `app/views/rules/your_rules/_your_rule.haml`
+
+## Frontend Components
+
+Located in `app/assets/javascripts/requirement_manager/`:
+
+| File | Purpose |
+|------|---------|
+| `controller.js.coffee` | Main controller, initializes components |
+| `searcher.js.coffee` | Select2 dropdown for choosing rules |
+| `requirement.js.coffee` | Model for a requirement instance |
+| `requirement_row.js.coffee` | Renders selected requirements |
+| `rule.js.coffee` | Model for available rules |
+| `store.js.coffee` | Simple key-value store for rules/requirements |
+| `add_button.js.coffee` | Handles the "Add Rule" button |
+| `new_requirement_positivity_toggle.js.coffee` | Must/Can't toggle buttons |
+
+### UI Flow
+
+1. User clicks "Must" or "Can't" toggle
+2. User selects a rule from the dropdown
+3. If variable rule, additional input appears (e.g., bedroom count selector)
+4. User clicks "Add Rule"
+5. Requirement row is added to the selected requirements list
+6. User submits form to save
+
+## View Integration
+
+The requirement manager is rendered via partial:
+
+```haml
+= render 'requirement_manager/form_fields',
+  form: f,
+  selected_requirements_heading: 'Rules for this Voucher',
+  hide_inherited: true,
+  note_context: :voucher
+```
+
+**Parameters:**
+- `form`: SimpleForm form builder
+- `selected_requirements_heading`: Label for the requirements section
+- `help_text`: Optional help text
+- `hide_inherited`: Hide inherited rules section
+- `on_unit`: Use alternate names for unit context
+- `section_header`: Override default "Rules" header
+- `note_context`: Context symbol for `selection_note` (e.g., `:voucher`)
+
+### Locations Used
+
+The requirement manager appears on:
+- `app/views/vouchers/edit.haml` - Individual voucher rules
+- `app/views/programs/_form.html.haml` - Program-level rules
+- `app/views/buildings/_form.html.haml` - Building rules
+- `app/views/units/_form.html.haml` - Unit rules
+- `app/views/funding_sources/edit.haml` - Funding source rules
+- `app/views/services/_form.html.haml` - Service rules
+- `app/views/subgrantees/_form.html.haml` - Subgrantee rules
+- `app/views/admin/users/_form.html.haml` - User requirement overrides
+- `app/views/admin/weighting_rules/_form.haml` - Weighting rules
+
+## Selection Notes
+
+Rules can provide context-specific notes via `selection_note(context:)`. This is useful when a rule behaves differently or needs explanation in certain contexts.
+
+Example from `Rules::Bedroom`:
+
+```ruby
+def selection_note(context: nil)
+  return unless context == :voucher
+
+  <<~NOTE
+    **Note:**
+    If this voucher is attached to a 2 bedroom unit...
+  NOTE
+end
+```
+
+Notes support Markdown formatting and are rendered when the rule is selected in the UI.


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)
* Adds a note for the Bedroom rule that shows up on the add voucher rules page
* Implements a structure such that extra notes for rules can be added and displayed in appropriate locations
* Adjusts translation interface to use a text area to support multi-line translations (matches warehouse)

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)
* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
