### PR TITLE
CAS Conditional use of auth for cache

### DIFF
--- a/app/models/application_notifier.rb
+++ b/app/models/application_notifier.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Manual testing routine
 # reload!; include NotifierConfig; setup_notifier('test_user')
 # @notifier.ping('test message')
@@ -31,10 +33,7 @@ class ApplicationNotifier < Slack::Notifier
 
   # use the same redis instance we use for caching
   def self.redis
-    Redis.new Rails.application.config_for(:cache_store).merge(
-      timeout: 1,
-      ssl: (ENV.fetch('CACHE_SSL') { 'false' }) == 'true',
-    )
+    Redis.new(Rails.application.config_for(:cache_store).merge(timeout: 1))
   end
 
   # prefix all keys with a CLIENT specific key

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,7 +4,13 @@ development:
 test:
   adapter: test
 
+<% redis_url = Rails.application.config_for(:cache_store)[:url] %>
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= redis_url %>
   channel_prefix: boston_ca_production
+
+staging:
+  adapter: redis
+  url: <%= redis_url %>
+  channel_prefix: boston_ca_staging

--- a/config/cache_store.yml
+++ b/config/cache_store.yml
@@ -1,4 +1,4 @@
-<% # Resolved Redis URL: REDIS_URL, else built from CACHE_*, else localhost fallback
+<% # Resolved Redis URL: REDIS_URL (as-is, no auth appended), else built from CACHE_* with auth, else localhost fallback
   redis_url = if ENV['REDIS_URL'].present?
     ENV['REDIS_URL']
   elsif ENV['CACHE_HOST'].present?
@@ -7,13 +7,6 @@
     "#{scheme}://#{auth}#{ENV['CACHE_HOST']}:#{ENV['CACHE_PORT']}/#{ENV['CACHE_DB'] || 0}"
   else
     'redis://localhost:6379/1'
-  end
-  use_redis_url = ENV['REDIS_URL'].present? %>
+  end %>
 <%= ENV.fetch('RAILS_ENV') { 'unknown' } %>:
-<% unless use_redis_url %>
-  host: <%= ENV['CACHE_HOST'] %>
-  port: <%= ENV['CACHE_PORT'] %>
-  db: <%= ENV['CACHE_DB'] %>
-<% end %>
   url: <%= redis_url %>
-<%= "  password: #{ENV['CACHE_AUTH_TOKEN']}\n" if ENV['CACHE_AUTH_TOKEN'].present? %>

--- a/config/cache_store.yml
+++ b/config/cache_store.yml
@@ -1,4 +1,19 @@
+<% # Resolved Redis URL: REDIS_URL, else built from CACHE_*, else localhost fallback
+  redis_url = if ENV['REDIS_URL'].present?
+    ENV['REDIS_URL']
+  elsif ENV['CACHE_HOST'].present?
+    scheme = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true' ? 'rediss' : 'redis'
+    auth = ENV['CACHE_AUTH_TOKEN'].present? ? ":#{ENV['CACHE_AUTH_TOKEN']}@" : ''
+    "#{scheme}://#{auth}#{ENV['CACHE_HOST']}:#{ENV['CACHE_PORT']}/#{ENV['CACHE_DB'] || 0}"
+  else
+    'redis://localhost:6379/1'
+  end
+  use_redis_url = ENV['REDIS_URL'].present? %>
 <%= ENV.fetch('RAILS_ENV') { 'unknown' } %>:
+<% unless use_redis_url %>
   host: <%= ENV['CACHE_HOST'] %>
   port: <%= ENV['CACHE_PORT'] %>
   db: <%= ENV['CACHE_DB'] %>
+<% end %>
+  url: <%= redis_url %>
+<%= "  password: #{ENV['CACHE_AUTH_TOKEN']}\n" if ENV['CACHE_AUTH_TOKEN'].present? %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,9 +36,13 @@ Rails.application.configure do
   else
     config.action_controller.perform_caching = false
 
-    cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
+    cache_ssl = ENV.fetch('CACHE_SSL') { 'false' } == 'true'
     cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-cas"
-    redis_config = Rails.application.config_for(:cache_store).merge({ expires_in: 5.minutes, ssl: cache_ssl, namespace: cache_namespace })
+    redis_config = Rails.application.config_for(:cache_store).merge(
+      expires_in: 5.minutes,
+      ssl: cache_ssl,
+      namespace: cache_namespace,
+    )
     config.cache_store = :redis_cache_store, redis_config
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,9 +69,14 @@ Rails.application.configure do
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
   # Use Redis cache store
-  cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
+  cache_ssl = ENV.fetch('CACHE_SSL') { 'false' } == 'true'
   cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-cas"
-  config.cache_store = :redis_cache_store, Rails.application.config_for(:cache_store).merge(expires_in: 8.hours, ssl: cache_ssl, namespace: cache_namespace)
+  redis_config = Rails.application.config_for(:cache_store).merge(
+    expires_in: 8.hours,
+    ssl: cache_ssl,
+    namespace: cache_namespace,
+  )
+  config.cache_store = :redis_cache_store, redis_config
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -66,9 +66,14 @@ Rails.application.configure do
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
   # Use Redis cache store
-  cache_ssl = (ENV.fetch('CACHE_SSL') { 'false' }) == 'true'
+  cache_ssl = ENV.fetch('CACHE_SSL') { 'false' } == 'true'
   cache_namespace = "#{ENV.fetch('CLIENT')}-#{Rails.env}-cas"
-  config.cache_store = :redis_cache_store, Rails.application.config_for(:cache_store).merge(expires_in: 8.hours, ssl: cache_ssl, namespace: cache_namespace)
+  redis_config = Rails.application.config_for(:cache_store).merge(
+    expires_in: 8.hours,
+    ssl: cache_ssl,
+    namespace: cache_namespace,
+  )
+  config.cache_store = :redis_cache_store, redis_config
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,6 @@ x-app: &app
     AWS_SECURITY_TOKEN: ${AWS_SECURITY_TOKEN:-}
     AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
     NODE_ENV: ${NODE_ENV:-development}
-    REDIS_URL: redis://redis:6379/
     BOOTSNAP_CACHE_DIR: /bundle/bootsnap
     K8S_API_HOST_AND_PORT: ${K8S_API_HOST_AND_PORT:-}
     KUBE_CONFIG_PATH: ${KUBE_CONFIG_PATH:-/home/app-user/.kube/config}
@@ -137,6 +136,16 @@ services:
 
   redis:
     image: redis:alpine
+    env_file:
+      - .env.local
+    command: >
+      sh -c '
+      if [ -n "$$CACHE_AUTH_TOKEN" ]; then
+        exec redis-server --requirepass "$$CACHE_AUTH_TOKEN";
+      else
+        exec redis-server;
+      fi
+      '
     volumes:
       - redis:/data
     ports:

--- a/spec/config/cache_auth_token_spec.rb
+++ b/spec/config/cache_auth_token_spec.rb
@@ -77,24 +77,18 @@ RSpec.describe 'Redis config (cache_store.yml)' do
   end
 
   describe 'password (cache_store.yml)' do
-    it 'omits password when CACHE_AUTH_TOKEN is unset' do
-      with_env('CACHE_AUTH_TOKEN' => nil) do
-        config = load_cache_store_config
-        expect(config).not_to have_key('password')
-      end
-    end
-
-    it 'omits password when CACHE_AUTH_TOKEN is blank' do
-      with_env('CACHE_AUTH_TOKEN' => '') do
-        config = load_cache_store_config
-        expect(config).not_to have_key('password')
-      end
-    end
-
-    it 'includes password when CACHE_AUTH_TOKEN is set' do
+    it 'never outputs separate password key (auth is in URL when built from CACHE_*)' do
       with_env('CACHE_AUTH_TOKEN' => 'devtoken') do
         config = load_cache_store_config
-        expect(config['password']).to eq('devtoken')
+        expect(config).not_to have_key('password')
+      end
+    end
+
+    it 'uses REDIS_URL as-is when set, ignoring CACHE_AUTH_TOKEN' do
+      with_env('REDIS_URL' => 'redis://redis:6379/', 'CACHE_AUTH_TOKEN' => 'ignored') do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://redis:6379/')
+        expect(config).not_to have_key('password')
       end
     end
   end

--- a/spec/config/cache_auth_token_spec.rb
+++ b/spec/config/cache_auth_token_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+
+# Tests the actual config/cache_store.yml by loading and evaluating it with different ENV.
+# All consumers (cache store, Action Cable, ApplicationNotifier) use config_for(:cache_store).
+#
+# Full end-to-end verification must be confirmed manually in dev/staging.
+RSpec.describe 'Redis config (cache_store.yml)' do
+  def with_env(env_vars)
+    originals = env_vars.keys.map { |k| [k, ENV[k]] }.to_h
+    env_vars.each do |k, v|
+      v.nil? ? ENV.delete(k) : ENV[k] = v
+    end
+    yield
+  ensure
+    originals.each do |k, v|
+      v.nil? ? ENV.delete(k) : ENV[k] = v
+    end
+  end
+
+  # Loads actual config/cache_store.yml, rendering ERB with current ENV
+  def load_cache_store_config
+    path = Rails.root.join('config', 'cache_store.yml')
+    content = ERB.new(File.read(path)).result(binding)
+    config = YAML.load(content)
+    env = ENV.fetch('RAILS_ENV') { 'test' }
+    (config[env] || {}).stringify_keys
+  end
+
+  describe 'redis_url resolution (cache_store.yml)' do
+    it 'uses REDIS_URL when set' do
+      with_env('REDIS_URL' => 'redis://myhost:6380/2', 'CACHE_HOST' => nil) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://myhost:6380/2')
+      end
+    end
+
+    it 'builds from CACHE_* when REDIS_URL is blank' do
+      with_env(
+        'REDIS_URL' => nil,
+        'CACHE_AUTH_TOKEN' => nil,
+        'CACHE_HOST' => 'redis',
+        'CACHE_PORT' => '6379',
+        'CACHE_DB' => '4',
+      ) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://redis:6379/4')
+      end
+    end
+
+    it 'includes auth in URL when CACHE_AUTH_TOKEN is set' do
+      with_env(
+        'REDIS_URL' => nil,
+        'CACHE_HOST' => 'redis',
+        'CACHE_PORT' => '6379',
+        'CACHE_DB' => '0',
+        'CACHE_AUTH_TOKEN' => 'secret',
+      ) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://:secret@redis:6379/0')
+      end
+    end
+
+    it 'falls back to localhost when neither REDIS_URL nor CACHE_HOST' do
+      with_env('REDIS_URL' => nil, 'CACHE_HOST' => nil) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://localhost:6379/1')
+      end
+    end
+  end
+
+  describe 'password (cache_store.yml)' do
+    it 'omits password when CACHE_AUTH_TOKEN is unset' do
+      with_env('CACHE_AUTH_TOKEN' => nil) do
+        config = load_cache_store_config
+        expect(config).not_to have_key('password')
+      end
+    end
+
+    it 'omits password when CACHE_AUTH_TOKEN is blank' do
+      with_env('CACHE_AUTH_TOKEN' => '') do
+        config = load_cache_store_config
+        expect(config).not_to have_key('password')
+      end
+    end
+
+    it 'includes password when CACHE_AUTH_TOKEN is set' do
+      with_env('CACHE_AUTH_TOKEN' => 'devtoken') do
+        config = load_cache_store_config
+        expect(config['password']).to eq('devtoken')
+      end
+    end
+  end
+
+  describe 'URL format (config_for[:url])' do
+    it 'omits auth when CACHE_AUTH_TOKEN is blank' do
+      with_env(
+        'REDIS_URL' => nil,
+        'CACHE_HOST' => 'redis',
+        'CACHE_PORT' => '6379',
+        'CACHE_DB' => '0',
+        'CACHE_AUTH_TOKEN' => nil,
+      ) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('redis://redis:6379/0')
+      end
+    end
+
+    it 'includes auth and uses rediss when CACHE_SSL and CACHE_AUTH_TOKEN set' do
+      with_env(
+        'REDIS_URL' => nil,
+        'CACHE_HOST' => 'redis',
+        'CACHE_PORT' => '6379',
+        'CACHE_DB' => '0',
+        'CACHE_SSL' => 'true',
+        'CACHE_AUTH_TOKEN' => 'valkey-token',
+      ) do
+        config = load_cache_store_config
+        expect(config['url']).to eq('rediss://:valkey-token@redis:6379/0')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Updates the cache to conditionally use CACHE_AUTH_TOKEN if provided. If no auth token is provided, continue using redis without requireing a password as it has been working. This will allow the app to work with the current cache setup as well as with the new cache setup once activated. This means deploys should not need to be synchronized with the cache update.

There were instances where the REDIS_URL environment variable was being used as the first check for the cache. This has been included in the update. The cache will build using REDIS_URL if available, if not, the cache is built from the CACHE_* variables, and the fallback of `redis://localhost:6379/1` remains as well.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
