### PR TITLE
Match History - Include more decision step data where possible

### DIFF
--- a/app/models/match_decisions/approve_match_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/approve_match_housing_subsidy_admin.rb
@@ -98,8 +98,8 @@ module MatchDecisions
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by?(contact)

--- a/app/models/match_decisions/base.rb
+++ b/app/models/match_decisions/base.rb
@@ -238,12 +238,57 @@ module MatchDecisions
     # on the prior step)
     def recreate_notifications_for_this_step
       notifications_for_this_step.each do |n|
-        n.create_for_match! match
+        n.create_for_match!(match, decision_id: id)
       end
     end
 
     def notifications_for_this_step
       # override in subclass, return an array of notifications appropriate to resend for the current step
+    end
+
+    def self.backfill_decision_id_on_events!
+      # Scope to decisions for matches that have notification delivery events with nil decision_id
+      decisions_scope = MatchDecisions::Base.where(
+        match_id: MatchEvents::NotificationDelivery.where(decision_id: nil).select(:match_id),
+      )
+
+      # Load events with nil decision_id, grouped by match (includes notification for type lookup)
+      match_ids = decisions_scope.distinct.pluck(:match_id)
+      events = MatchEvents::NotificationDelivery
+        .where(decision_id: nil, match_id: match_ids)
+        .includes(:notification)
+
+      events_by_match = events.group_by(&:match_id)
+      decision_to_event_ids = Hash.new { |h, k| h[k] = [] }
+
+      # Store decisions per match to avoid repeated queries
+      decisions_by_match = {}
+
+      decisions_scope.find_each do |decision|
+        notification_classes = decision.notifications_for_this_step
+        next if notification_classes.blank?
+
+        # Load all decisions for this match (cached per match)
+        decisions_by_match[decision.match_id] ||= MatchDecisions::Base.where(match_id: decision.match_id).to_a
+        match_decisions = decisions_by_match[decision.match_id]
+
+        # Consider only events for this match
+        (events_by_match[decision.match_id] || []).each do |event|
+          next unless notification_classes.include?(event.notification.class)
+
+          # Only assign when this decision is the only one in the match that sends this notification type
+          decisions_sending_this_notification = match_decisions.select do |d|
+            d.notifications_for_this_step.include?(event.notification.class)
+          end
+
+          decision_to_event_ids[decision.id] << event.id if decisions_sending_this_notification.size == 1
+        end
+      end
+
+      # Persist decision_id on events
+      decision_to_event_ids.each do |decision_id, event_ids|
+        MatchEvents::NotificationDelivery.where(id: event_ids).update_all(decision_id: decision_id)
+      end
     end
 
     def holds_voucher?
@@ -304,8 +349,21 @@ module MatchDecisions
       MatchEvents::UnitUpdated.create(match_id: match.id, note: "Previously: #{previous_unit}", contact_id: contact_id)
     end
 
-    # override in subclass
-    def notify_contact_of_action_taken_on_behalf_of contact:
+    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
+      return unless notify_on_behalf_of?
+      return if skip_notify_on_behalf_of_when_canceled? && status == 'canceled'
+
+      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type, decision_id: id
+    end
+
+    # Override to return true when this decision should send OnBehalfOf notification
+    def notify_on_behalf_of?
+      false
+    end
+
+    # Override to return true to skip notification when status is 'canceled'
+    def skip_notify_on_behalf_of_when_canceled?
+      false
     end
 
     def self.model_name
@@ -386,7 +444,7 @@ module MatchDecisions
 
     def send_notifications_for_step
       notifications_for_this_step.each do |notification|
-        notification.create_for_match! match
+        notification.create_for_match!(match, decision_id: id)
       end
     end
 

--- a/app/models/match_decisions/eight/eight_record_voucher_date.rb
+++ b/app/models/match_decisions/eight/eight_record_voucher_date.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Eight
   class EightRecordVoucherDate < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -79,8 +81,8 @@ module MatchDecisions::Eight
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/eleven/eleven_hsa_accepts_client.rb
+++ b/app/models/match_decisions/eleven/eleven_hsa_accepts_client.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Eleven
   class ElevenHsaAcceptsClient < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -82,8 +84,8 @@ module MatchDecisions::Eleven
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/four/approve_match_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/four/approve_match_housing_subsidy_admin.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Four
   class ApproveMatchHousingSubsidyAdmin < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -89,8 +91,8 @@ module MatchDecisions::Four
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/four/match_recommendation_hsa.rb
+++ b/app/models/match_decisions/four/match_recommendation_hsa.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Four
   class MatchRecommendationHsa < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -85,8 +87,12 @@ module MatchDecisions::Four
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/four/match_recommendation_shelter_agency.rb
+++ b/app/models/match_decisions/four/match_recommendation_shelter_agency.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Four
   class MatchRecommendationShelterAgency < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -89,8 +91,12 @@ module MatchDecisions::Four
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match!(match, contact_actor_type) unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by?(contact)

--- a/app/models/match_decisions/four/record_client_housed_date_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/four/record_client_housed_date_housing_subsidy_administrator.rb
@@ -87,8 +87,12 @@ module MatchDecisions::Four
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/four/schedule_criminal_hearing_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/four/schedule_criminal_hearing_housing_subsidy_admin.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Four
   class ScheduleCriminalHearingHousingSubsidyAdmin < ::MatchDecisions::Base
     include MatchDecisions::RouteFourCancelReasons
@@ -78,8 +80,12 @@ module MatchDecisions::Four
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def permitted_params

--- a/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
+++ b/app/models/match_decisions/homeless_set_aside/set_asides_hsa_accepts_client.rb
@@ -73,8 +73,8 @@ module MatchDecisions::HomelessSetAside
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/homeless_set_aside/set_asides_record_client_housed_date_or_decline_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/homeless_set_aside/set_asides_record_client_housed_date_or_decline_housing_subsidy_administrator.rb
@@ -101,8 +101,12 @@ module MatchDecisions::HomelessSetAside
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/match_recommendation_shelter_agency.rb
+++ b/app/models/match_decisions/match_recommendation_shelter_agency.rb
@@ -91,8 +91,12 @@ module MatchDecisions
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/nine/nine_record_voucher_date.rb
+++ b/app/models/match_decisions/nine/nine_record_voucher_date.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Nine
   class NineRecordVoucherDate < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -90,8 +92,8 @@ module MatchDecisions::Nine
       Notifications::Nine::NineRecordVoucherDate.create_for_match! match
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/provider_only/hsa_accepts_client.rb
+++ b/app/models/match_decisions/provider_only/hsa_accepts_client.rb
@@ -82,8 +82,8 @@ module MatchDecisions::ProviderOnly
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/record_client_housed_date_housing_subsidy_administrator.rb
+++ b/app/models/match_decisions/record_client_housed_date_housing_subsidy_administrator.rb
@@ -109,8 +109,12 @@ module MatchDecisions
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by?(contact)

--- a/app/models/match_decisions/record_client_housed_date_shelter_agency.rb
+++ b/app/models/match_decisions/record_client_housed_date_shelter_agency.rb
@@ -63,8 +63,8 @@ module MatchDecisions
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/schedule_criminal_hearing_housing_subsidy_admin.rb
@@ -104,8 +104,12 @@ module MatchDecisions
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def permitted_params

--- a/app/models/match_decisions/seven/approve_match_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/seven/approve_match_housing_subsidy_admin.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Seven
   class ApproveMatchHousingSubsidyAdmin < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -79,8 +81,8 @@ module MatchDecisions::Seven
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/six/approve_match_housing_subsidy_admin.rb
+++ b/app/models/match_decisions/six/approve_match_housing_subsidy_admin.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Six
   class ApproveMatchHousingSubsidyAdmin < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -84,8 +86,8 @@ module MatchDecisions::Six
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of contact: # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match! match, contact_actor_type
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/six/match_recommendation_shelter_agency.rb
+++ b/app/models/match_decisions/six/match_recommendation_shelter_agency.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Six
   class MatchRecommendationShelterAgency < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -86,8 +88,12 @@ module MatchDecisions::Six
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match!(match, contact_actor_type) unless status == 'canceled'
+    def notify_on_behalf_of?
+      true
+    end
+
+    def skip_notify_on_behalf_of_when_canceled?
+      true
     end
 
     def accessible_by?(contact)

--- a/app/models/match_decisions/ten/ten_agency_confirm_match_success.rb
+++ b/app/models/match_decisions/ten/ten_agency_confirm_match_success.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Ten
   class TenAgencyConfirmMatchSuccess < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -72,8 +74,8 @@ module MatchDecisions::Ten
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match!(match, contact_actor_type)
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/match_decisions/twelve/twelve_hsa_confirm_match_success.rb
+++ b/app/models/match_decisions/twelve/twelve_hsa_confirm_match_success.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 module MatchDecisions::Twelve
   class TwelveHsaConfirmMatchSuccess < ::MatchDecisions::Base
     include MatchDecisions::AcceptsDeclineReason
@@ -81,8 +83,8 @@ module MatchDecisions::Twelve
       end
     end
 
-    def notify_contact_of_action_taken_on_behalf_of(contact:) # rubocop:disable Lint/UnusedMethodArgument
-      Notifications::OnBehalfOf.create_for_match!(match, contact_actor_type)
+    def notify_on_behalf_of?
+      true
     end
 
     def accessible_by? contact

--- a/app/models/notifications/base.rb
+++ b/app/models/notifications/base.rb
@@ -22,6 +22,8 @@ module Notifications
     delegate :name, to: :recipient, allow_nil: true, prefix: true
     has_many :notification_delivery_events, class_name: 'MatchEvents::NotificationDelivery', foreign_key: :notification_id
 
+    attribute :decision_id_for_delivery, :integer
+
     validates :code, uniqueness: true
 
     before_validation :setup_code
@@ -36,13 +38,15 @@ module Notifications
     end
 
     def deliver
-      DeliverJob.perform_later(self) if match.match_route.send_notifications
+      return unless match.match_route.send_notifications
+
+      DeliverJob.perform_later(self, decision_id_for_delivery)
     end
 
     class DeliverJob < ActiveJob::Base
-      def perform(notification)
+      def perform(notification, decision_id = nil)
         NotificationsMailer.send(notification.notification_type, notification).deliver_now
-        notification.record_delivery_event!
+        notification.record_delivery_event!(decision_id: decision_id)
       end
     end
     private_constant :DeliverJob
@@ -58,7 +62,7 @@ module Notifications
     end
 
     def decision
-      nil
+      notification_delivery_events.last&.decision
     end
 
     def event_label
@@ -66,12 +70,21 @@ module Notifications
       raise 'abstract method not implemented'
     end
 
-    def record_delivery_event!
-      notification_delivery_events.create! match: match, contact: recipient
+    def record_delivery_event!(decision_id: nil)
+      decision_id_to_use = decision_id || decision&.id
+      notification_delivery_events.create!(match: match, contact: recipient, decision_id: decision_id_to_use)
     end
 
     def contacts_editable?
       false
+    end
+
+    def self.create_for_match!(match, decision_id: nil)
+      contact_types_for_notification.each do |contact_type|
+        match.send(contact_type).each do |contact|
+          create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
+        end
+      end
     end
 
     def self.recreate_for_match! match, contact

--- a/app/models/notifications/confirm_housing_subsidy_admin_decline_dnd_staff.rb
+++ b/app/models/notifications/confirm_housing_subsidy_admin_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_housing_subsidy_admin_decline_dnd_staff_decision
     end

--- a/app/models/notifications/confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/confirm_shelter_agency_decline_dnd_staff.rb
+++ b/app/models/notifications/confirm_shelter_agency_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_shelter_agency_decline_dnd_staff_decision
     end

--- a/app/models/notifications/criminal_hearing_scheduled_client.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_client.rb
@@ -12,14 +12,6 @@ module Notifications
       [:client_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       Translation.translate('Client sent notice of criminal background hearing date.')
     end

--- a/app/models/notifications/criminal_hearing_scheduled_dnd_staff.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       label = Translation.translate('DND')
       label += ' '

--- a/app/models/notifications/criminal_hearing_scheduled_housing_subsidy_admin.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_housing_subsidy_admin.rb
@@ -12,14 +12,6 @@ module Notifications
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       label = Translation.translate('Housing Subsidy Administrator')
       label += ' '

--- a/app/models/notifications/criminal_hearing_scheduled_hsp.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_hsp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:hsp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       label = Translation.translate('Housing Search Provider')
       label += ' '

--- a/app/models/notifications/criminal_hearing_scheduled_shelter_agency.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       label = Translation.translate('Shelter Agency')
       label += ' '

--- a/app/models/notifications/criminal_hearing_scheduled_ssp.rb
+++ b/app/models/notifications/criminal_hearing_scheduled_ssp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:ssp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       label = Translation.translate('Stabilization Services Provider')
       label += ' '

--- a/app/models/notifications/eight/eight_assign_manager.rb
+++ b/app/models/notifications/eight/eight_assign_manager.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_assign_manager_decision
     end

--- a/app/models/notifications/eight/eight_confirm_assign_manager_decline.rb
+++ b/app/models/notifications/eight/eight_confirm_assign_manager_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_confirm_assign_manager_decline_decision
     end

--- a/app/models/notifications/eight/eight_confirm_lease_up_decline.rb
+++ b/app/models/notifications/eight/eight_confirm_lease_up_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_confirm_lease_up_decline_decision
     end

--- a/app/models/notifications/eight/eight_confirm_match_success.rb
+++ b/app/models/notifications/eight/eight_confirm_match_success.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_confirm_match_success_decision
     end

--- a/app/models/notifications/eight/eight_confirm_voucher_decline.rb
+++ b/app/models/notifications/eight/eight_confirm_voucher_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_confirm_voucher_decline_decision
     end

--- a/app/models/notifications/eight/eight_lease_up.rb
+++ b/app/models/notifications/eight/eight_lease_up.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_lease_up_decision
     end

--- a/app/models/notifications/eight/eight_record_voucher_date.rb
+++ b/app/models/notifications/eight/eight_record_voucher_date.rb
@@ -12,14 +12,6 @@ module Notifications::Eight
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eight_record_voucher_date_decision
     end

--- a/app/models/notifications/eight/match_canceled.rb
+++ b/app/models/notifications/eight/match_canceled.rb
@@ -13,12 +13,8 @@ module Notifications::Eight
       [:contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
+    def self.create_for_match!(match, decision_id: nil)
+      Notifications::Base.instance_method(:create_for_match!).bind(self).call(match, decision_id: decision_id)
     end
   end
 end

--- a/app/models/notifications/eight/match_declined.rb
+++ b/app/models/notifications/eight/match_declined.rb
@@ -13,11 +13,11 @@ module Notifications::Eight
       []
     end
 
-    def self.create_for_match! match
+    def self.create_for_match!(match, decision_id: nil)
       contacts = match.contacts - match.dnd_staff_contacts
 
       contacts.each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
   end

--- a/app/models/notifications/eleven/confirm_hsa_decline_dnd_staff.rb
+++ b/app/models/notifications/eleven/confirm_hsa_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/eleven/confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.eleven_confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/eleven/hsa_accepts_client.rb
+++ b/app/models/notifications/eleven/hsa_accepts_client.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/hsa_accepts_client_ssp_notification.rb
+++ b/app/models/notifications/eleven/hsa_accepts_client_ssp_notification.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/hsa_decision_client.rb
+++ b/app/models/notifications/eleven/hsa_decision_client.rb
@@ -14,14 +14,6 @@ module Notifications::Eleven
       [:client_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/hsa_decision_hsp.rb
+++ b/app/models/notifications/eleven/hsa_decision_hsp.rb
@@ -14,14 +14,6 @@ module Notifications::Eleven
       [:hsp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/hsa_decision_shelter_agency.rb
+++ b/app/models/notifications/eleven/hsa_decision_shelter_agency.rb
@@ -16,14 +16,6 @@ module Notifications::Eleven
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/hsa_decision_ssp.rb
+++ b/app/models/notifications/eleven/hsa_decision_ssp.rb
@@ -14,14 +14,6 @@ module Notifications::Eleven
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/match_initiation_for_hsa.rb
+++ b/app/models/notifications/eleven/match_initiation_for_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/match_initiation_for_shelter_agency.rb
+++ b/app/models/notifications/eleven/match_initiation_for_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/eleven/match_initiation_for_ssp.rb
+++ b/app/models/notifications/eleven/match_initiation_for_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Eleven
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/five/application_submission.rb
+++ b/app/models/notifications/five/application_submission.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_application_submission_decision
     end

--- a/app/models/notifications/five/client_agrees.rb
+++ b/app/models/notifications/five/client_agrees.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_client_agrees_decision
     end

--- a/app/models/notifications/five/lease_up.rb
+++ b/app/models/notifications/five/lease_up.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_lease_up_decision
     end

--- a/app/models/notifications/five/match_canceled.rb
+++ b/app/models/notifications/five/match_canceled.rb
@@ -13,12 +13,8 @@ module Notifications::Five
       [:contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
+    def self.create_for_match!(match, decision_id: nil)
+      Notifications::Base.instance_method(:create_for_match!).bind(self).call(match, decision_id: decision_id)
     end
   end
 end

--- a/app/models/notifications/five/match_recommendation.rb
+++ b/app/models/notifications/five/match_recommendation.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_match_recommendation_decision
     end

--- a/app/models/notifications/five/mitigation.rb
+++ b/app/models/notifications/five/mitigation.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_mitigation_decision
     end

--- a/app/models/notifications/five/screening.rb
+++ b/app/models/notifications/five/screening.rb
@@ -12,14 +12,6 @@ module Notifications::Five
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.five_screening_decision
     end

--- a/app/models/notifications/four/housing_subsidy_administrator_accepted.rb
+++ b/app/models/notifications/four/housing_subsidy_administrator_accepted.rb
@@ -12,14 +12,6 @@ module Notifications::Four
       [:shelter_agency_contacts, :dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.four_schedule_criminal_hearing_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/four/match_canceled.rb
+++ b/app/models/notifications/four/match_canceled.rb
@@ -13,12 +13,8 @@ module Notifications::Four
       [:contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
+    def self.create_for_match!(match, decision_id: nil)
+      Notifications::Base.instance_method(:create_for_match!).bind(self).call(match, decision_id: decision_id)
     end
   end
 end

--- a/app/models/notifications/four/match_declined.rb
+++ b/app/models/notifications/four/match_declined.rb
@@ -13,11 +13,11 @@ module Notifications::Four
       []
     end
 
-    def self.create_for_match! match
+    def self.create_for_match!(match, decision_id: nil)
       contacts = match.contacts - match.dnd_staff_contacts
 
       contacts.each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
   end

--- a/app/models/notifications/four/match_recommendation_housing_subsidy_admin.rb
+++ b/app/models/notifications/four/match_recommendation_housing_subsidy_admin.rb
@@ -12,14 +12,6 @@ module Notifications::Four
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} notified of match recommendation"
     end

--- a/app/models/notifications/four/match_recommendation_hsa.rb
+++ b/app/models/notifications/four/match_recommendation_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Four
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} notified of potential match"
     end

--- a/app/models/notifications/four/shelter_agency_accepted.rb
+++ b/app/models/notifications/four/shelter_agency_accepted.rb
@@ -12,14 +12,6 @@ module Notifications::Four
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.four_match_recommendation_hsa_decision
     end

--- a/app/models/notifications/homeless_set_aside/confirm_hsa_decline_dnd_staff.rb
+++ b/app/models/notifications/homeless_set_aside/confirm_hsa_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.set_asides_confirm_hsa_accepts_client_decline_dnd_staff_decision
     end

--- a/app/models/notifications/homeless_set_aside/hsa_accepts_client.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_accepts_client.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} reviews match with client"
     end

--- a/app/models/notifications/homeless_set_aside/hsa_accepts_client_ssp_notification.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_accepts_client_ssp_notification.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('SSP')} notified of #{Translation.translate('Housing Subsidy Administrator')} acceptance"
     end

--- a/app/models/notifications/homeless_set_aside/hsa_decision_client.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_decision_client.rb
@@ -14,14 +14,6 @@ module Notifications::HomelessSetAside
       [:client_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Client sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/homeless_set_aside/hsa_decision_hsp.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_decision_hsp.rb
@@ -14,14 +14,6 @@ module Notifications::HomelessSetAside
       [:hsp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Search Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/homeless_set_aside/hsa_decision_shelter_agency.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_decision_shelter_agency.rb
@@ -16,14 +16,6 @@ module Notifications::HomelessSetAside
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency Contact')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/homeless_set_aside/hsa_decision_ssp.rb
+++ b/app/models/notifications/homeless_set_aside/hsa_decision_ssp.rb
@@ -14,14 +14,6 @@ module Notifications::HomelessSetAside
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Stabilization Services Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/homeless_set_aside/match_initiation_for_hsa.rb
+++ b/app/models/notifications/homeless_set_aside/match_initiation_for_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} notified of match detail"
     end

--- a/app/models/notifications/homeless_set_aside/match_initiation_for_shelter_agency.rb
+++ b/app/models/notifications/homeless_set_aside/match_initiation_for_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency Contact')} notified of match detail"
     end

--- a/app/models/notifications/homeless_set_aside/match_initiation_for_ssp.rb
+++ b/app/models/notifications/homeless_set_aside/match_initiation_for_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('SSP')} notified of match detail"
     end

--- a/app/models/notifications/homeless_set_aside/set_aside_first_step_shelter_agency.rb
+++ b/app/models/notifications/homeless_set_aside/set_aside_first_step_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency Contact')} notified of match detail"
     end

--- a/app/models/notifications/homeless_set_aside/set_aside_match_complete_shelter_agency.rb
+++ b/app/models/notifications/homeless_set_aside/set_aside_match_complete_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::HomelessSetAside
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency Contact')} notified of match completion"
     end

--- a/app/models/notifications/housing_opportunity_successfully_filled.rb
+++ b/app/models/notifications/housing_opportunity_successfully_filled.rb
@@ -12,14 +12,6 @@ module Notifications
       [:contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       'Contact notified that vacancy was filled by other client'
     end

--- a/app/models/notifications/housing_subsidy_admin_accepted_match_development_officer.rb
+++ b/app/models/notifications/housing_subsidy_admin_accepted_match_development_officer.rb
@@ -16,14 +16,6 @@ module Notifications
       [:do_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision to #{Translation.translate('Development Officer')}"
     end

--- a/app/models/notifications/housing_subsidy_admin_accepted_match_dnd_staff.rb
+++ b/app/models/notifications/housing_subsidy_admin_accepted_match_dnd_staff.rb
@@ -16,14 +16,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision to #{Translation.translate('DND')}"
     end

--- a/app/models/notifications/housing_subsidy_admin_decision_client.rb
+++ b/app/models/notifications/housing_subsidy_admin_decision_client.rb
@@ -14,14 +14,6 @@ module Notifications
       [:client_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Client sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/housing_subsidy_admin_decision_development_officer.rb
+++ b/app/models/notifications/housing_subsidy_admin_decision_development_officer.rb
@@ -14,14 +14,6 @@ module Notifications
       [:do_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Development Officer')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/housing_subsidy_admin_decision_hsp.rb
+++ b/app/models/notifications/housing_subsidy_admin_decision_hsp.rb
@@ -14,14 +14,6 @@ module Notifications
       [:hsp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Search Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/housing_subsidy_admin_decision_shelter_agency.rb
+++ b/app/models/notifications/housing_subsidy_admin_decision_shelter_agency.rb
@@ -14,14 +14,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/housing_subsidy_admin_decision_ssp.rb
+++ b/app/models/notifications/housing_subsidy_admin_decision_ssp.rb
@@ -14,14 +14,6 @@ module Notifications
       [:ssp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Stabilization Services Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/housing_subsidy_admin_declined_match_hsp.rb
+++ b/app/models/notifications/housing_subsidy_admin_declined_match_hsp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:hsp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision to #{Translation.translate('Housing Search Provider')}"
     end

--- a/app/models/notifications/housing_subsidy_admin_declined_match_shelter_agency.rb
+++ b/app/models/notifications/housing_subsidy_admin_declined_match_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision to #{Translation.translate('Shelter Agency')}"
     end

--- a/app/models/notifications/housing_subsidy_admin_declined_match_ssp.rb
+++ b/app/models/notifications/housing_subsidy_admin_declined_match_ssp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:ssp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision to #{Translation.translate('Stabilization Services Provider')}"
     end

--- a/app/models/notifications/match_canceled.rb
+++ b/app/models/notifications/match_canceled.rb
@@ -13,13 +13,13 @@ module Notifications
       []
     end
 
-    def self.create_for_match!(match)
+    def self.create_for_match!(match, decision_id: nil)
       contacts = match.contacts - match.dnd_staff_contacts
       # don't send to the HSA, SSP, or HSP contacts unless they have been involved
       contacts -= (match.housing_subsidy_admin_contacts + match.ssp_contacts + match.hsp_contacts) unless match.hsa_involved?
 
       contacts.each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
 

--- a/app/models/notifications/match_declined.rb
+++ b/app/models/notifications/match_declined.rb
@@ -12,14 +12,6 @@ module Notifications
       [:contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       'Contacts notified, match declined'
     end

--- a/app/models/notifications/match_initiation_for_manual_notification.rb
+++ b/app/models/notifications/match_initiation_for_manual_notification.rb
@@ -13,14 +13,14 @@ module Notifications
       [] # Not applicable - uses dynamic contact type from match.match_route.initial_contacts_for_match
     end
 
-    def self.create_for_match! match
+    def self.create_for_match!(match, decision_id: nil)
       match.send(match.match_route.initial_contacts_for_match).each do |contact|
         # this notification includes a link to the un-started matches, don't send anything
         # if the user can't access the link
         user = contact.user
         next unless user&.can_see_alternate_matches? || user&.can_see_all_alternate_matches?
 
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
 

--- a/app/models/notifications/match_recommendation_client.rb
+++ b/app/models/notifications/match_recommendation_client.rb
@@ -12,14 +12,6 @@ module Notifications
       [:client_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       'Client notified of potential match'
     end

--- a/app/models/notifications/match_recommendation_dnd_staff.rb
+++ b/app/models/notifications/match_recommendation_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.match_recommendation_dnd_staff_decision
     end

--- a/app/models/notifications/match_recommendation_housing_subsidy_admin.rb
+++ b/app/models/notifications/match_recommendation_housing_subsidy_admin.rb
@@ -12,14 +12,6 @@ module Notifications
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} notified of potential match (no client details sent)"
     end

--- a/app/models/notifications/match_recommendation_hsp.rb
+++ b/app/models/notifications/match_recommendation_hsp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:hsp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Search Provider')} notified of potential match (no client details sent)"
     end

--- a/app/models/notifications/match_recommendation_shelter_agency.rb
+++ b/app/models/notifications/match_recommendation_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.match_recommendation_shelter_agency_decision
     end

--- a/app/models/notifications/match_recommendation_ssp.rb
+++ b/app/models/notifications/match_recommendation_ssp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:ssp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Stabilization Service Provider')} notified of potential match (no client details sent)"
     end

--- a/app/models/notifications/match_rejected.rb
+++ b/app/models/notifications/match_rejected.rb
@@ -12,14 +12,6 @@ module Notifications
       [:contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       'Contacts notified, match rejected'
     end

--- a/app/models/notifications/match_success_confirmed.rb
+++ b/app/models/notifications/match_success_confirmed.rb
@@ -12,14 +12,6 @@ module Notifications
       [:contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       'Contact notified of match success confirmation.'
     end

--- a/app/models/notifications/match_success_confirmed_development_officer.rb
+++ b/app/models/notifications/match_success_confirmed_development_officer.rb
@@ -12,14 +12,6 @@ module Notifications
       [:do_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Development Officer')} notified of match success confirmation."
     end

--- a/app/models/notifications/move_in_date_set.rb
+++ b/app/models/notifications/move_in_date_set.rb
@@ -17,14 +17,6 @@ module Notifications
       ]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency')}, #{Translation.translate('Housing Subsidy Administrator')}, #{Translation.translate('Stabilization Service Provider')}, and #{Translation.translate('Housing Search Provider')} contacts notified, #{Translation.translate('lease start date')} set."
     end

--- a/app/models/notifications/nine/match_canceled.rb
+++ b/app/models/notifications/nine/match_canceled.rb
@@ -13,12 +13,8 @@ module Notifications::Nine
       [:contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
+    def self.create_for_match!(match, decision_id: nil)
+      Notifications::Base.instance_method(:create_for_match!).bind(self).call(match, decision_id: decision_id)
     end
   end
 end

--- a/app/models/notifications/nine/match_declined.rb
+++ b/app/models/notifications/nine/match_declined.rb
@@ -13,11 +13,11 @@ module Notifications::Nine
       []
     end
 
-    def self.create_for_match! match
+    def self.create_for_match!(match, decision_id: nil)
       contacts = match.contacts - match.dnd_staff_contacts
 
       contacts.each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
   end

--- a/app/models/notifications/nine/nine_assign_case_contact.rb
+++ b/app/models/notifications/nine/nine_assign_case_contact.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_assign_case_contact_decision
     end

--- a/app/models/notifications/nine/nine_assign_manager.rb
+++ b/app/models/notifications/nine/nine_assign_manager.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_assign_manager_decision
     end

--- a/app/models/notifications/nine/nine_confirm_assign_manager_decline.rb
+++ b/app/models/notifications/nine/nine_confirm_assign_manager_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_confirm_assign_manager_decline_decision
     end

--- a/app/models/notifications/nine/nine_confirm_lease_up_decline.rb
+++ b/app/models/notifications/nine/nine_confirm_lease_up_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_confirm_lease_up_decline_decision
     end

--- a/app/models/notifications/nine/nine_confirm_match_success.rb
+++ b/app/models/notifications/nine/nine_confirm_match_success.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_confirm_match_success_decision
     end

--- a/app/models/notifications/nine/nine_confirm_voucher_decline.rb
+++ b/app/models/notifications/nine/nine_confirm_voucher_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_confirm_voucher_decline_decision
     end

--- a/app/models/notifications/nine/nine_lease_up.rb
+++ b/app/models/notifications/nine/nine_lease_up.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_lease_up_decision
     end

--- a/app/models/notifications/nine/nine_match_in_progress.rb
+++ b/app/models/notifications/nine/nine_match_in_progress.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_record_voucher_date_decision
     end

--- a/app/models/notifications/nine/nine_match_success.rb
+++ b/app/models/notifications/nine/nine_match_success.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_confirm_match_success_decision
     end

--- a/app/models/notifications/nine/nine_record_voucher_date.rb
+++ b/app/models/notifications/nine/nine_record_voucher_date.rb
@@ -12,14 +12,6 @@ module Notifications::Nine
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.nine_record_voucher_date_decision
     end

--- a/app/models/notifications/no_longer_working_with_client.rb
+++ b/app/models/notifications/no_longer_working_with_client.rb
@@ -14,14 +14,6 @@ module Notifications
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('DND')} notified, contact no longer working with client"
     end

--- a/app/models/notifications/on_behalf_of.rb
+++ b/app/models/notifications/on_behalf_of.rb
@@ -13,9 +13,9 @@ module Notifications
       [] # Not applicable - contact_type is passed as parameter to create_for_match!
     end
 
-    def self.create_for_match! match, contact_type
+    def self.create_for_match!(match, contact_type, decision_id: nil)
       match.send(contact_type).each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
 

--- a/app/models/notifications/progress_update_submitted.rb
+++ b/app/models/notifications/progress_update_submitted.rb
@@ -20,14 +20,6 @@ module Notifications
       ]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       if Config.get(:notify_all_on_progress_update)
         'Progress update submitted, all contacts notified'

--- a/app/models/notifications/provider_only/confirm_hsa_decline_dnd_staff.rb
+++ b/app/models/notifications/provider_only/confirm_hsa_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_hsa_accepts_client_decline_dnd_staff_decision
     end

--- a/app/models/notifications/provider_only/hsa_accepts_client.rb
+++ b/app/models/notifications/provider_only/hsa_accepts_client.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} reviews match with client"
     end

--- a/app/models/notifications/provider_only/hsa_accepts_client_ssp_notification.rb
+++ b/app/models/notifications/provider_only/hsa_accepts_client_ssp_notification.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('SSP')} notified of #{Translation.translate('Housing Subsidy Administrator')} acceptance"
     end

--- a/app/models/notifications/provider_only/hsa_decision_client.rb
+++ b/app/models/notifications/provider_only/hsa_decision_client.rb
@@ -14,14 +14,6 @@ module Notifications::ProviderOnly
       [:client_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "Client sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/provider_only/hsa_decision_hsp.rb
+++ b/app/models/notifications/provider_only/hsa_decision_hsp.rb
@@ -14,14 +14,6 @@ module Notifications::ProviderOnly
       [:hsp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Search Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/provider_only/hsa_decision_shelter_agency.rb
+++ b/app/models/notifications/provider_only/hsa_decision_shelter_agency.rb
@@ -16,14 +16,6 @@ module Notifications::ProviderOnly
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/provider_only/hsa_decision_ssp.rb
+++ b/app/models/notifications/provider_only/hsa_decision_ssp.rb
@@ -14,14 +14,6 @@ module Notifications::ProviderOnly
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Stabilization Services Provider')} sent notice of #{Translation.translate('Housing Subsidy Administrator')}'s decision."
     end

--- a/app/models/notifications/provider_only/match_initiation_for_hsa.rb
+++ b/app/models/notifications/provider_only/match_initiation_for_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Housing Subsidy Administrator')} notified of match detail"
     end

--- a/app/models/notifications/provider_only/match_initiation_for_shelter_agency.rb
+++ b/app/models/notifications/provider_only/match_initiation_for_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('Shelter Agency')} notified of match detail"
     end

--- a/app/models/notifications/provider_only/match_initiation_for_ssp.rb
+++ b/app/models/notifications/provider_only/match_initiation_for_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::ProviderOnly
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def event_label
       "#{Translation.translate('SSP')} notified of match detail"
     end

--- a/app/models/notifications/record_client_housed_date_housing_subsidy_administrator.rb
+++ b/app/models/notifications/record_client_housed_date_housing_subsidy_administrator.rb
@@ -12,14 +12,6 @@ module Notifications
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.record_client_housed_date_housing_subsidy_administrator_decision
     end

--- a/app/models/notifications/record_client_housed_date_shelter_agency.rb
+++ b/app/models/notifications/record_client_housed_date_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.record_client_housed_date_shelter_agency_decision
     end

--- a/app/models/notifications/schedule_criminal_hearing_housing_subsidy_admin.rb
+++ b/app/models/notifications/schedule_criminal_hearing_housing_subsidy_admin.rb
@@ -12,14 +12,6 @@ module Notifications
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.schedule_criminal_hearing_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/schedule_criminal_hearing_hsp.rb
+++ b/app/models/notifications/schedule_criminal_hearing_hsp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:hsp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.schedule_criminal_hearing_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/schedule_criminal_hearing_ssp.rb
+++ b/app/models/notifications/schedule_criminal_hearing_ssp.rb
@@ -12,14 +12,6 @@ module Notifications
       [:ssp_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.schedule_criminal_hearing_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/seven/approve_match_housing_subsidy_admin_from_dnd.rb
+++ b/app/models/notifications/seven/approve_match_housing_subsidy_admin_from_dnd.rb
@@ -12,14 +12,6 @@ module Notifications::Seven
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.seven_approve_match_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/seven/confirm_hsa_decline_dnd_staff.rb
+++ b/app/models/notifications/seven/confirm_hsa_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Seven
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.seven_confirm_housing_subsidy_admin_decline_dnd_staff_decision
     end

--- a/app/models/notifications/seven/confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/seven/confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Seven
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.seven_confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/seven/match_canceled.rb
+++ b/app/models/notifications/seven/match_canceled.rb
@@ -13,12 +13,8 @@ module Notifications::Seven
       [:contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
+    def self.create_for_match!(match, decision_id: nil)
+      Notifications::Base.instance_method(:create_for_match!).bind(self).call(match, decision_id: decision_id)
     end
   end
 end

--- a/app/models/notifications/seven/match_declined.rb
+++ b/app/models/notifications/seven/match_declined.rb
@@ -13,11 +13,11 @@ module Notifications::Seven
       []
     end
 
-    def self.create_for_match! match
+    def self.create_for_match!(match, decision_id: nil)
       contacts = match.contacts - match.dnd_staff_contacts
 
       contacts.each do |contact|
-        create! match: match, recipient: contact
+        create!(match: match, recipient: contact, decision_id_for_delivery: decision_id)
       end
     end
   end

--- a/app/models/notifications/seven/match_in_progress_shelter_agency.rb
+++ b/app/models/notifications/seven/match_in_progress_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Seven
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.seven_approve_match_housing_subsidy_admin_decision
     end

--- a/app/models/notifications/seven/match_success_shelter_agency.rb
+++ b/app/models/notifications/seven/match_success_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Seven
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.seven_confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/shelter_agency_accepted.rb
+++ b/app/models/notifications/shelter_agency_accepted.rb
@@ -15,14 +15,6 @@ module Notifications
       ]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.match_recommendation_shelter_agency_decision
     end

--- a/app/models/notifications/shelter_agency_decline_accepted.rb
+++ b/app/models/notifications/shelter_agency_decline_accepted.rb
@@ -12,14 +12,6 @@ module Notifications
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match!(match)
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_shelter_agency_decline_dnd_staff_decision
     end

--- a/app/models/notifications/six/approve_match_housing_subsidy_admin.rb
+++ b/app/models/notifications/six/approve_match_housing_subsidy_admin.rb
@@ -12,14 +12,6 @@ module Notifications::Six
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/six/confirm_hsa_decline_dnd_staff.rb
+++ b/app/models/notifications/six/confirm_hsa_decline_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Six
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/six/confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/six/confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Six
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/six/confirm_match_success_shelter_agency.rb
+++ b/app/models/notifications/six/confirm_match_success_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Six
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def notification_type
       # prefix used for finding relevant information in other objects
       # e.g. mailer, match decisions

--- a/app/models/notifications/ten/ten_agency_confirm_match_success.rb
+++ b/app/models/notifications/ten/ten_agency_confirm_match_success.rb
@@ -12,14 +12,6 @@ module Notifications::Ten
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.ten_agency_confirm_match_success_decision
     end

--- a/app/models/notifications/ten/ten_agency_confirm_match_success_decline.rb
+++ b/app/models/notifications/ten/ten_agency_confirm_match_success_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Ten
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_housing_subsidy_admin_decline_dnd_staff_decision
     end

--- a/app/models/notifications/ten/ten_confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/ten/ten_confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Ten
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.ten_confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/thirteen/thirteen_accept_referral_decline.rb
+++ b/app/models/notifications/thirteen/thirteen_accept_referral_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_accept_referral_decline_decision
     end

--- a/app/models/notifications/thirteen/thirteen_accept_referral_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_accept_referral_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_accept_referral_decision
     end

--- a/app/models/notifications/thirteen/thirteen_accept_referral_hsp.rb
+++ b/app/models/notifications/thirteen/thirteen_accept_referral_hsp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:hsp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_accept_referral_decision
     end

--- a/app/models/notifications/thirteen/thirteen_accept_referral_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_accept_referral_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_accept_referral_decision
     end

--- a/app/models/notifications/thirteen/thirteen_accept_referral_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_accept_referral_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_accept_referral_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_match.rb
+++ b/app/models/notifications/thirteen/thirteen_client_match.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_match_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_review_decline.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_review_decline_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_review_dnd_staff.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_review_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_review_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_client_review_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_client_review_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_client_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/thirteen/thirteen_confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_confirm_match_success_decision
     end

--- a/app/models/notifications/thirteen/thirteen_confirm_match_success_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_confirm_match_success_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_confirm_match_success_decision
     end

--- a/app/models/notifications/thirteen/thirteen_confirm_match_success_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_confirm_match_success_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_confirm_match_success_decision
     end

--- a/app/models/notifications/thirteen/thirteen_confirm_match_success_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_confirm_match_success_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_confirm_match_success_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_decline.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_outcome_decline_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_dnd_staff.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_outcome_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_outcome_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_outcome_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_outcome_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_outcome_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_outcome_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_decline.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_scheduled_decline_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_dnd_staff.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_scheduled_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_scheduled_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_scheduled_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hearing_scheduled_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hearing_scheduled_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hearing_scheduled_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_decline.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hsa_review_decline_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_dnd_staff.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hsa_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hsa_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hsa_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_hsa_review_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_hsa_review_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_hsa_review_decision
     end

--- a/app/models/notifications/thirteen/thirteen_match_acknowledgement_hsa.rb
+++ b/app/models/notifications/thirteen/thirteen_match_acknowledgement_hsa.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_match_acknowledgement_decision
     end

--- a/app/models/notifications/thirteen/thirteen_match_acknowledgement_shelter_agency.rb
+++ b/app/models/notifications/thirteen/thirteen_match_acknowledgement_shelter_agency.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_match_acknowledgement_decision
     end

--- a/app/models/notifications/thirteen/thirteen_match_acknowledgement_ssp.rb
+++ b/app/models/notifications/thirteen/thirteen_match_acknowledgement_ssp.rb
@@ -12,14 +12,6 @@ module Notifications::Thirteen
       [:ssp_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.thirteen_match_acknowledgement_decision
     end

--- a/app/models/notifications/twelve/twelve_agency_acknowledges_receipt.rb
+++ b/app/models/notifications/twelve/twelve_agency_acknowledges_receipt.rb
@@ -12,14 +12,6 @@ module Notifications::Twelve
       [:shelter_agency_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.twelve_agency_acknowledges_receipt_decision
     end

--- a/app/models/notifications/twelve/twelve_agency_acknowledges_receipt_decline.rb
+++ b/app/models/notifications/twelve/twelve_agency_acknowledges_receipt_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Twelve
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_housing_subsidy_admin_decline_dnd_staff_decision
     end

--- a/app/models/notifications/twelve/twelve_confirm_match_success_dnd_staff.rb
+++ b/app/models/notifications/twelve/twelve_confirm_match_success_dnd_staff.rb
@@ -12,14 +12,6 @@ module Notifications::Twelve
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.twelve_confirm_match_success_dnd_staff_decision
     end

--- a/app/models/notifications/twelve/twelve_hsa_confirm_match_decline.rb
+++ b/app/models/notifications/twelve/twelve_hsa_confirm_match_decline.rb
@@ -12,14 +12,6 @@ module Notifications::Twelve
       [:dnd_staff_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.confirm_housing_subsidy_admin_decline_dnd_staff_decision
     end

--- a/app/models/notifications/twelve/twelve_hsa_confirm_match_success.rb
+++ b/app/models/notifications/twelve/twelve_hsa_confirm_match_success.rb
@@ -12,14 +12,6 @@ module Notifications::Twelve
       [:housing_subsidy_admin_contacts]
     end
 
-    def self.create_for_match! match
-      contact_types_for_notification.each do |contact_type|
-        match.send(contact_type).each do |contact|
-          create! match: match, recipient: contact
-        end
-      end
-    end
-
     def decision
       match.twelve_hsa_confirm_match_success_decision
     end

--- a/spec/models/match_decisions/base_notifications_spec.rb
+++ b/spec/models/match_decisions/base_notifications_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+include ActiveJob::TestHelper
+
+RSpec.describe MatchDecisions::Base, type: :model do
+  describe '#notify_contact_of_action_taken_on_behalf_of' do
+    let(:route) do
+      r = MatchRoutes::Default.first
+      r.update(send_notifications: true) unless r.send_notifications?
+      r
+    end
+    let(:program) { create(:program, match_route: route) }
+    let(:sub_program) { create(:sub_program, program: program) }
+    let(:voucher) { create(:voucher, sub_program: sub_program) }
+    let(:opportunity) { create(:opportunity, voucher: voucher) }
+    let(:match) { create(:client_opportunity_match, match_route: route, opportunity: opportunity, active: true) }
+    let(:shelter_contact) { create(:contact, email: 'shelter@example.com') }
+    let(:admin_contact) { create(:contact, email: 'admin@example.com') }
+
+    before do
+      match.shelter_agency_contacts << shelter_contact
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    context 'when decision has notify_on_behalf_of? true' do
+      let(:decision) do
+        create(
+          :match_decisions_match_recommendation_shelter_agency,
+          match: match,
+          status: 'accepted',
+          contact: admin_contact,
+          client_spoken_with_services_agency: true,
+          cori_release_form_submitted: true,
+          release_of_information: '1',
+        )
+      end
+
+      it 'creates OnBehalfOf notifications for contact_actor_type' do
+        expect do
+          decision.notify_contact_of_action_taken_on_behalf_of contact: admin_contact
+        end.to change { Notifications::OnBehalfOf.count }.by(1)
+      end
+
+      it 'passes decision_id to OnBehalfOf.create_for_match!' do
+        perform_enqueued_jobs do
+          decision.notify_contact_of_action_taken_on_behalf_of contact: admin_contact
+        end
+
+        event = MatchEvents::NotificationDelivery.find_by(
+          match_id: match.id,
+          notification: Notifications::OnBehalfOf.last,
+        )
+        expect(event.decision_id).to eq(decision.id)
+      end
+    end
+
+    context 'when decision has skip_notify_on_behalf_of_when_canceled? true and status is canceled' do
+      let(:decision) do
+        create(
+          :match_decisions_match_recommendation_shelter_agency,
+          :cancel_reason,
+          match: match,
+          status: 'canceled',
+          contact: admin_contact,
+        )
+      end
+
+      it 'does not create OnBehalfOf notifications' do
+        expect do
+          decision.notify_contact_of_action_taken_on_behalf_of contact: admin_contact
+        end.not_to(change { Notifications::OnBehalfOf.count })
+      end
+    end
+  end
+
+  describe '.backfill_decision_id_on_events!' do
+    let(:route) do
+      r = MatchRoutes::Default.first
+      r.update(send_notifications: false)
+      r
+    end
+    let(:program) { create(:program, match_route: route) }
+    let(:sub_program) { create(:sub_program, program: program) }
+    let(:voucher) { create(:voucher, sub_program: sub_program) }
+    let(:opportunity) { create(:opportunity, voucher: voucher) }
+    let(:match) { create(:client_opportunity_match, match_route: route, opportunity: opportunity) }
+    let(:shelter_contact) { create(:contact, email: 'shelter@example.com') }
+    let(:decision) { match.match_recommendation_shelter_agency_decision }
+
+    before do
+      match.shelter_agency_contacts << shelter_contact
+      decision.update!(
+        status: 'accepted',
+        client_spoken_with_services_agency: true,
+        cori_release_form_submitted: true,
+        release_of_information: '1',
+      )
+    end
+
+    it 'updates notification_delivery_events with nil decision_id to use decision id' do
+      notification = Notifications::MatchRecommendationShelterAgency.create!(
+        match: match,
+        recipient: shelter_contact,
+      )
+      event = notification.notification_delivery_events.create!(
+        match: match,
+        contact: shelter_contact,
+        decision_id: nil,
+      )
+
+      MatchDecisions::Base.backfill_decision_id_on_events!
+
+      expect(event.reload.decision_id).to eq(decision.id)
+    end
+  end
+end

--- a/spec/models/notifications/base_spec.rb
+++ b/spec/models/notifications/base_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+require 'rails_helper'
+include ActiveJob::TestHelper
+
+RSpec.describe Notifications::Base, type: :model do
+  describe '.create_for_match!' do
+    let(:route) do
+      r = MatchRoutes::Default.first
+      r.update(send_notifications: true) unless r.send_notifications?
+      r
+    end
+    let(:match) do
+      create(:client_opportunity_match, match_route: route)
+    end
+    let(:shelter_contact) { create(:contact, email: 'shelter@example.com') }
+    let(:decision) do
+      create(
+        :match_decisions_match_recommendation_shelter_agency,
+        match: match,
+        status: 'accepted',
+        client_spoken_with_services_agency: true,
+        cori_release_form_submitted: true,
+        release_of_information: '1',
+      )
+    end
+
+    before do
+      match.shelter_agency_contacts << shelter_contact
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it 'passes decision_id to notifications and stores it on delivery events' do
+      perform_enqueued_jobs do
+        Notifications::MatchRecommendationShelterAgency.create_for_match!(match, decision_id: decision.id)
+      end
+
+      notification = Notifications::MatchRecommendationShelterAgency.find_by(
+        client_opportunity_match_id: match.id,
+        recipient: shelter_contact,
+      )
+      event = notification.notification_delivery_events.last
+      expect(event.decision_id).to eq(decision.id)
+    end
+  end
+
+  describe '#record_delivery_event!' do
+    let(:route) do
+      r = MatchRoutes::Default.first
+      r.update(send_notifications: false)
+      r
+    end
+    let(:match) { create(:client_opportunity_match, match_route: route) }
+    let(:contact) { create(:contact, email: 'test@example.com') }
+
+    it 'stores decision_id on the delivery event when provided' do
+      notification = Notifications::MatchRecommendationShelterAgency.create!(
+        match: match,
+        recipient: contact,
+      )
+      decision_id = 42
+      notification.record_delivery_event!(decision_id: decision_id)
+
+      event = notification.notification_delivery_events.last
+      expect(event.decision_id).to eq(decision_id)
+    end
+
+    it 'allows nil decision_id when notification has no associated decision' do
+      notification = Notifications::OnBehalfOf.create!(
+        match: match,
+        recipient: contact,
+      )
+      notification.record_delivery_event!(decision_id: nil)
+
+      event = notification.notification_delivery_events.last
+      expect(event.decision_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Propagates decision_id from decisions to notification delivery events so events are tied to the decision that created them. 

The backfill only sets decision_id when a single decision in the match sends that notification type, avoiding overlap and incorrect assignment. 

OnBehalfOf logic is centralized using notify_on_behalf_of? and skip_notify_on_behalf_of_when_canceled? instead of per-decision overrides. Redundant create_for_match! implementations in notification subclasses are removed in favor of the base implementation.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

New Feature, Code Cleanup

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
