### PR TITLE
Pin trivy-action to safe SHA (supply chain compromise)

### DIFF
--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -173,7 +173,7 @@ jobs:
       # https://github.com/aquasecurity/trivy-action
       - name: Run vulnerability scan
         id: vuln_scan
-        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # 0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         env:
           TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db:2"
           TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db:1"


### PR DESCRIPTION
## Summary

- Pins `aquasecurity/trivy-action` to SHA `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (tag 0.35.0)
- This is the only version **not** affected by the [March 19 supply chain compromise](https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise)
- All other tags (0.0.1 through 0.34.2) were force-pushed to malicious commits that exfiltrate secrets from CI runners
- This repo was already SHA-pinned (safe from the tag rewrite), but updating to the latest safe version

## Test plan

- [ ] Verify workflow runs successfully with the pinned SHA
- [ ] Confirm trivy scan output is normal