### PR TITLE
Date Time Picker Replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ storage/
 docker/nginx-proxy/certs
 prometheus-metrics/**
 
+# Devbox local environment (gems, nix store, etc.)
+.devbox/
+
 # Include Devbox files
 !devbox.json
 !devbox.lock

--- a/Gemfile
+++ b/Gemfile
@@ -101,10 +101,8 @@ gem 'maxminddb' # for local geocoding of login attempts
 gem 'geocoder'
 
 gem 'attribute_normalizer'
-gem 'bootstrap3-datetimepicker-rails', '~> 4.17.42'
 gem 'fuzzy_match'
 gem 'handlebars_assets'
-gem 'momentjs-rails', '>= 2.9.0'
 
 gem 'delayed_job_active_record'
 gem 'terser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,8 +205,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    bootstrap3-datetimepicker-rails (4.17.47)
-      momentjs-rails (>= 2.8.1)
     brakeman (8.0.4)
       racc
     browser (6.2.0)
@@ -431,8 +429,6 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    momentjs-rails (2.29.4.1)
-      railties (>= 3.1)
     msgpack (1.8.0)
     multi_json (1.19.1)
     mutex_m (0.3.0)
@@ -773,7 +769,6 @@ DEPENDENCIES
   bcrypt
   benchmark
   bootsnap
-  bootstrap3-datetimepicker-rails (~> 4.17.42)
   brakeman
   browser
   bundler-audit
@@ -820,7 +815,6 @@ DEPENDENCIES
   memery
   mini_portile2
   minitest-reporters
-  momentjs-rails (>= 2.9.0)
   mutex_m
   net-http
   nokogiri
@@ -936,7 +930,6 @@ CHECKSUMS
   bigdecimal (4.1.0) sha256=6dc07767aa3dc456ccd48e7ae70a07b474e9afd7c5bc576f80bd6da5c8dd6cae
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  bootstrap3-datetimepicker-rails (4.17.47) sha256=ee87a9bad74c140729f6a1ea2a7f3f2d9aaefa7e9defbe31b4edd27ff64689a2
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
@@ -1034,7 +1027,6 @@ CHECKSUMS
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   minitest-reporters (1.7.1) sha256=5060413a0c95b8c32fe73e0606f3631c173a884d7900e50013e15094eb50562c
-  momentjs-rails (2.29.4.1) sha256=c7f9bc583872b628f8723319f4ae12a646c858c1c3ddb352bc75d5a7aa0b9e01
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   multi_json (1.19.1) sha256=7aefeff8f2c854bf739931a238e4aea64592845e0c0395c8a7d2eea7fdd631b7
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751

--- a/app/assets/javascripts/legacy.js
+++ b/app/assets/javascripts/legacy.js
@@ -15,7 +15,6 @@
 // Vendor libs
 ////////////////////
 //= require jquery3
-//= require moment
 //= require jquery_ujs
 //= require handlebars.runtime
 //= require select2

--- a/app/inputs/date_time_picker_input.rb
+++ b/app/inputs/date_time_picker_input.rb
@@ -1,0 +1,62 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class DateTimePickerInput < SimpleForm::Inputs::StringInput
+  DATETIME_TD_OPTIONS = {
+    display: {
+      components: {
+        clock: true,
+        hours: true,
+        minutes: true,
+      },
+      sideBySide: true,
+    },
+    stepping: 15,
+    localization: {
+      format: 'MMM d, yyyy h:mm T',
+    },
+  }.freeze
+
+  def input(wrapper_options)
+    set_html_options
+    set_value_html_option
+
+    template.content_tag :div, class: 'input-group date datepicker', data: { controller: 'datepicker', date_options: DATETIME_TD_OPTIONS.to_json } do
+      input = super(wrapper_options)
+      input + input_button
+    end
+  end
+
+  def input_html_classes
+    super + ['datepicker', 'form-control']
+  end
+
+  private
+
+  def input_button
+    template.content_tag :span, '', class: 'input-group-text icon-calendar', data: { td_toggle: 'datetimepicker' }
+  end
+
+  def set_html_options
+    input_html_options[:type] = 'text'
+  end
+
+  def set_value_html_option
+    return unless value.present?
+
+    input_html_options[:value] ||= value.strftime(display_pattern)
+  end
+
+  def value
+    object.send(attribute_name) if object.respond_to?(attribute_name)
+  end
+
+  def display_pattern
+    I18n.t('datetimepicker.dformat', default: '%b %-d, %Y %-l:%M %p')
+  end
+end

--- a/app/javascript/controllers/datepicker_controller.js
+++ b/app/javascript/controllers/datepicker_controller.js
@@ -55,7 +55,7 @@ export default class extends Controller {
       ? JSON.parse(this.element.dataset.dateOptions)
       : {}
 
-    const finalOptions = { ...defaultOptions, ...elementOptions }
+    const finalOptions = this.deepMerge(defaultOptions, elementOptions)
 
     this.datepicker = new TempusDominus(this.element, finalOptions)
 
@@ -67,7 +67,7 @@ export default class extends Controller {
     this.element.addEventListener('change.td', (_event) => {
       const inputField = this.element.querySelector('input')
       if (inputField) {
-        inputField.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }))
+        inputField.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true, detail: true }))
       }
     })
   }
@@ -118,7 +118,19 @@ export default class extends Controller {
       if (parsed) return parsed
     }
 
+    const configuredFormat = optionsData.localization?.format || ''
+    const isDateTimeFormat = /[hHtT]/.test(configuredFormat)
+
+    const dateTimeFormats = isDateTimeFormat ? [
+      'MMM d, yyyy h:mm T',
+      'MMM d, yyyy h:mm t',
+      'MMMM d, yyyy h:mm T',
+      'MMMM d, yyyy h:mm t',
+      'MMM d, yyyy HH:mm',
+    ] : []
+
     const formats = [
+      ...dateTimeFormats,
       'MMM d, yyyy',
       'MMMM d, yyyy',
       'MM/dd/yyyy',
@@ -166,5 +178,24 @@ export default class extends Controller {
     if (source === source.toUpperCase()) return target.toUpperCase()
     if (source === source.toLowerCase()) return target.toLowerCase()
     return target[0].toUpperCase() + target.slice(1)
+  }
+
+  deepMerge(target, source) {
+    const result = { ...target }
+    for (const key of Object.keys(source)) {
+      if (
+        source[key] !== null &&
+        typeof source[key] === 'object' &&
+        !Array.isArray(source[key]) &&
+        target[key] !== null &&
+        typeof target[key] === 'object' &&
+        !Array.isArray(target[key])
+      ) {
+        result[key] = this.deepMerge(target[key], source[key])
+      } else {
+        result[key] = source[key]
+      }
+    }
+    return result
   }
 }

--- a/app/views/match_decisions/_schedule_criminal_hearing_housing_subsidy_admin.haml
+++ b/app/views/match_decisions/_schedule_criminal_hearing_housing_subsidy_admin.haml
@@ -24,7 +24,7 @@
                 %label(for="decision_criminal_hearing_date")= Translation.translate('Date and time of criminal background hearing')
                 .row.form-group
                   .col-md-6
-                    = form.input :criminal_hearing_date, as: :string, label: false, disabled: !@decision.editable?, input_html: {class: :date_time_picker, style: 'width: 15em;'}
+                    = form.input :criminal_hearing_date, as: :date_time_picker, label: false, disabled: !@decision.editable?
 
               = form.input :note, as: :text, input_html: {rows: 4, disabled: !@decision.editable?}
               = render 'match_decisions/continue_button', text: 'Continue Match', icon: 'checkmark', button_attributes: {class: 'btn btn-success jSubmit', disabled: !@decision.editable?}
@@ -36,18 +36,6 @@
 
 = content_for :page_js do
   :javascript
-    $('.date_time_picker').datetimepicker({
-      sideBySide: true,
-      stepping: 15,
-      format: "MMM D, YYYY h:mm a",
-      icons: {
-        time: "icon icon-clock",
-        date: "icon icon-calendar",
-        up: "icon icon-arrow-up",
-        down: "icon icon-arrow-down"
-      }
-    });
-
     function update_button_states() {
         var prevent_matching_present = $('#decision_prevent_matching_until').val() != ''
         if(prevent_matching_present) {

--- a/app/views/match_decisions/thirteen/_hearing_outcome.haml
+++ b/app/views/match_decisions/thirteen/_hearing_outcome.haml
@@ -22,25 +22,13 @@
                 %label(for="decision_criminal_hearing_date")= "Hearing Outcome"
                 .row.form-group
                   .col-md-6
-                    = form.input :criminal_hearing_date, as: :string, label: false, disabled: !@decision.editable?, input_html: {class: :date_time_picker, style: 'width: 15em;'}
+                    = form.input :criminal_hearing_date, as: :date_time_picker, label: false, disabled: !@decision.editable?
 
               = render 'match_decisions/continue_button', text: 'Continue Match', icon: 'checkmark', button_attributes: { class: 'btn btn-success jSubmit', data: {submit_param_name: 'decision[status]', submit_param_value: 'accepted'}, disabled: (!@decision.editable?) }
         = render 'match_decisions/decline_and_cancel_backup_actions', form: form, action_message: "If the match is declined, the #{Translation.translate('CoC Thirteen')} will be informed of the decision."
 
 = content_for :page_js do
   :javascript
-    $('.date_time_picker').datetimepicker({
-      sideBySide: true,
-      stepping: 15,
-      format: "MMM D, YYYY h:mm a",
-      icons: {
-        time: "icon icon-clock",
-        date: "icon icon-calendar",
-        up: "icon icon-arrow-up",
-        down: "icon icon-arrow-down"
-      }
-    });
-
     function update_button_states() {
         var prevent_matching_present = $('#decision_prevent_matching_until').val() != ''
         if(prevent_matching_present) {

--- a/app/views/match_decisions/thirteen/_hearing_scheduled.haml
+++ b/app/views/match_decisions/thirteen/_hearing_scheduled.haml
@@ -13,25 +13,13 @@
                 %label(for="decision_criminal_hearing_date")= Translation.translate('Date and time of criminal background hearing')
                 .row.form-group
                   .col-md-6
-                    = form.input :criminal_hearing_date, as: :string, label: false, disabled: !@decision.editable?, input_html: {class: :date_time_picker, style: 'width: 15em;'}
+                    = form.input :criminal_hearing_date, as: :date_time_picker, label: false, disabled: !@decision.editable?
 
               = render 'match_decisions/continue_button', text: 'Continue Match', icon: 'checkmark', button_attributes: { class: 'btn btn-success jSubmit', data: {submit_param_name: 'decision[status]', submit_param_value: 'accepted'}, disabled: (!@decision.editable?) }
         = render 'match_decisions/decline_and_cancel_backup_actions', form: form, action_message: "If the match is declined, the #{Translation.translate('CoC Thirteen')} will be informed of the decision."
 
 = content_for :page_js do
   :javascript
-    $('.date_time_picker').datetimepicker({
-      sideBySide: true,
-      stepping: 15,
-      format: "MMM D, YYYY h:mm a",
-      icons: {
-        time: "icon icon-clock",
-        date: "icon icon-calendar",
-        up: "icon icon-arrow-up",
-        down: "icon icon-arrow-down"
-      }
-    });
-
     function update_button_states() {
         var prevent_matching_present = $('#decision_prevent_matching_until').val() != ''
         if(prevent_matching_present) {

--- a/spec/inputs/date_time_picker_input_spec.rb
+++ b/spec/inputs/date_time_picker_input_spec.rb
@@ -1,0 +1,104 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DateTimePickerInput do
+  let(:model_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :scheduled_at, :datetime
+
+      def self.name
+        'TestDecision'
+      end
+
+      def self.human_attribute_name(attr, **_opts)
+        attr.to_s.humanize
+      end
+
+      def self.validators_on(*)
+        []
+      end
+
+      def self.reflect_on_association(*)
+        nil
+      end
+    end
+  end
+
+  let(:model) { model_class.new }
+
+  let(:view_context) do
+    controller = ActionController::Base.new
+    controller.request = ActionDispatch::TestRequest.create
+    av = ActionView::Base.new(ActionController::Base.view_paths, {}, controller)
+    av.extend(SimpleForm::ActionViewExtensions::FormHelper)
+    av
+  end
+
+  let(:builder) { SimpleForm::FormBuilder.new(:decision, model, view_context, {}) }
+  let(:html) { Capybara.string(builder.input(:scheduled_at, as: :date_time_picker, label: false)) }
+
+  describe 'DATETIME_TD_OPTIONS' do
+    subject(:options) { described_class::DATETIME_TD_OPTIONS }
+
+    it 'enables clock, hours, and minutes components' do
+      expect(options.dig(:display, :components, :clock)).to be true
+      expect(options.dig(:display, :components, :hours)).to be true
+      expect(options.dig(:display, :components, :minutes)).to be true
+    end
+
+    it 'enables side-by-side display' do
+      expect(options.dig(:display, :sideBySide)).to be true
+    end
+
+    it 'sets 15-minute stepping' do
+      expect(options[:stepping]).to eq 15
+    end
+
+    it 'uses the datetime format string' do
+      expect(options.dig(:localization, :format)).to eq 'MMM d, yyyy h:mm T'
+    end
+  end
+
+  describe 'rendered HTML' do
+    it 'wraps the input in a datepicker controller element' do
+      expect(html).to have_css('div.input-group.date.datepicker[data-controller="datepicker"]')
+    end
+
+    it 'includes the calendar toggle button' do
+      expect(html).to have_css('[data-td-toggle="datetimepicker"]')
+    end
+
+    it 'serialises DATETIME_TD_OPTIONS into data-date-options' do
+      node = html.find('[data-controller="datepicker"]')
+      parsed = JSON.parse(node['data-date-options'])
+      expect(parsed.dig('display', 'sideBySide')).to be true
+      expect(parsed['stepping']).to eq 15
+    end
+
+    context 'when the attribute has an existing datetime value' do
+      before { model.scheduled_at = Time.zone.local(2026, 3, 15, 14, 30) }
+
+      it 'pre-populates the input with the formatted datetime' do
+        input_value = html.find('input[type="text"]')['value']
+        expect(input_value).to eq 'Mar 15, 2026 2:30 PM'
+      end
+    end
+
+    context 'when the attribute is nil' do
+      it 'renders an empty input' do
+        input_value = html.find('input[type="text"]')['value']
+        expect(input_value).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

* The Bootstrap datetime picker was broken after the 4 -> 5 migration
* Uses TempusDominus, which we already use for dates to replace that functionality

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
