### PR TITLE
[#9273] JS and color regression fixes

### DIFF
--- a/app/assets/javascripts/requirement_manager/searcher.js.coffee
+++ b/app/assets/javascripts/requirement_manager/searcher.js.coffee
@@ -31,8 +31,10 @@ class App.RequirementManager.Searcher
       $(".jVariableRequirment").hide()
       $(".jRuleSelectionNote").hide()
       $(".jVariableRequirment[data-rule-id=#{rule_id}]").show()
-      $(".jVariableRequirment[data-rule-id=#{rule_id}] select").css('width', '100%')
-      $(".jVariableRequirment[data-rule-id=#{rule_id}] select").select2()
+      $variableSelect = $(".jVariableRequirment[data-rule-id=#{rule_id}] select")
+      $variableSelect.css('width', '100%')
+      $variableSelect.select2
+        dropdownParent: $(@element).closest('form')
       $(".jRuleSelectionNote[data-rule-id=#{rule_id}]").show()
 
   reset: ->

--- a/app/assets/stylesheets/overrides/_select2.scss
+++ b/app/assets/stylesheets/overrides/_select2.scss
@@ -12,19 +12,23 @@
   align-items: flex-start;
   // background-color: #f9f9f9;
 }
+
 .select2-container .select2-selection--multiple {
   max-height: 150px;
   overflow-y: auto;
   padding: 0.75rem 1.25rem;
 }
 
-.select2-container--bootstrap .select2-results__option--highlighted[aria-selected] {
+.select2-container--bootstrap .select2-results__option--highlighted[aria-selected],
+.select2-container--default .select2-results__option--highlighted.select2-results__option--selectable {
   background-color: var(--brand-primary);
+  color: #ffffff;
 }
 
 .select2-results__option[aria-selected="true"] {
   display: flex;
   justify-content: space-between;
+
   &::after {
     font-family: 'icons';
     content: get-icon-code('checkmark');
@@ -43,6 +47,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
   &,
   b {
     position: static;
@@ -51,20 +56,22 @@
 }
 
 .select2--full-width {
+
   &,
-  + .select2-container {
+  +.select2-container {
     width: 100% !important; // Override mis-computed inline width
   }
 }
 
 .select2--with-prepends {
-  + .select2-container .select2-selection {
+  +.select2-container .select2-selection {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     flex: 1 1 auto;
     min-width: 300px;
   }
-  + .select2-container {
+
+  +.select2-container {
     width: auto !important;
     flex: 1 1 auto;
   }
@@ -89,6 +96,7 @@
   &:only-child {
     padding: 0;
   }
+
   li:only-child {
     width: 100%;
   }
@@ -98,8 +106,7 @@
   margin: 2px 2px 2px 0;
 }
 
-.form--label-hint-wrapper
-{
+.form--label-hint-wrapper {
   display: flex;
   align-content: space-between;
 }
@@ -114,10 +121,12 @@
   justify-content: flex-end;
   padding-left: space(4);
   white-space: nowrap;
+
   &:hover {
     color: $link-hover-color;
     cursor: pointer;
   }
+
   // Fix for IE11 bug with align-center in container with
   // min-height
   &::after {


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Fixes two regressions from the Bootstrap upgrade.
1. Voucher rule variable options we're working in the modal, the select 2 target was wrong.
2. Text color in select 2 items was dark on a dark background, changed to white.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
