### PR TITLE
[#9314] Match Reopening and Match Starting Fixes

### DIFF
--- a/app/controllers/opportunity_matches_controller.rb
+++ b/app/controllers/opportunity_matches_controller.rb
@@ -122,10 +122,12 @@ class OpportunityMatchesController < ApplicationController
   end
 
   # You can activate a match if all of the following are true:
-  # 1. the match hasn't succeeded
-  # 2. you have can edit all clients or this opportunity is editable by you
-  # 3. you've been given the can activate matches permission
+  # 1. the opportunity's voucher is available
+  # 2. the match hasn't succeeded
+  # 3. you have can edit all clients or this opportunity is editable by you
+  # 4. you've been given the can activate matches permission
   def can_activate_match?
+    return false unless @opportunity.voucher&.available?
     return false if @opportunity.successful_match
     return false unless current_user.can_edit_all_clients? || @opportunity.editable_by?(current_user)
 

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -722,12 +722,22 @@ class ClientOpportunityMatch < ApplicationRecord
 
   def reopen!(contact, user: nil)
     self.class.transaction do
+      # Determine the decision the match was closed at *before* we clear the
+      # closed state. `current_decision` returns nil while closed, and once
+      # reopened it identifies the active step of an open match by status
+      # (pending/acknowledged/expiration_update) -- which skips right over the
+      # terminal `canceled`/`declined` decision we actually want to reactivate
+      # and can land on an earlier step that still carries an `acknowledged`
+      # status. `unsuccessful_decision` finds the decision that actually closed
+      # the match.
+      decision_to_reopen = unsuccessful_decision
+
       # Park client on any other routes where this route is set to block matching when the client is involved in this route
       match_route.routes_parked_on_active_match.reject(&:empty?).each do |park_route|
         client.make_unavailable_in(match_route: park_route.constantize, user: user, match: self, reason: UnavailableAsCandidateFor::ACTIVE_MATCH_TEXT)
       end
       update(closed: false, active: true, closed_reason: nil)
-      current_decision.update(status: :pending)
+      (decision_to_reopen || current_decision).update(status: :pending)
       MatchEvents::Reopened.create(match_id: id, contact_id: contact.id)
       # If this match was picked up in nightly processing, the client now appears as housed in the warehouse,
       # so clean that up...

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -472,6 +472,14 @@ class ClientOpportunityMatch < ApplicationRecord
     @current_decision ||= initialized_decisions.order_as_specified(type: later_decisions_first).limit(1).first
   end
 
+  # The decision the match was closed at -- the one reopen! should reactivate.
+  # Must be called while the match is still closed (relies on the closed_reason).
+  def closing_decision
+    return send(match_route.success_decision) if successful?
+
+    unsuccessful_decision
+  end
+
   def unsuccessful_decision
     return canceled_decision if canceled?
 
@@ -726,11 +734,11 @@ class ClientOpportunityMatch < ApplicationRecord
       # closed state. `current_decision` returns nil while closed, and once
       # reopened it identifies the active step of an open match by status
       # (pending/acknowledged/expiration_update) -- which skips right over the
-      # terminal `canceled`/`declined` decision we actually want to reactivate
-      # and can land on an earlier step that still carries an `acknowledged`
-      # status. `unsuccessful_decision` finds the decision that actually closed
-      # the match.
-      decision_to_reopen = unsuccessful_decision
+      # terminal `success`/`canceled`/`declined` decision we actually want to
+      # reactivate and can land on an earlier step that still carries an
+      # `acknowledged` status. `closing_decision` finds the decision that
+      # actually closed the match.
+      decision_to_reopen = closing_decision
 
       # Park client on any other routes where this route is set to block matching when the client is involved in this route
       match_route.routes_parked_on_active_match.reject(&:empty?).each do |park_route|

--- a/app/models/client_opportunity_match.rb
+++ b/app/models/client_opportunity_match.rb
@@ -747,11 +747,13 @@ class ClientOpportunityMatch < ApplicationRecord
       update(closed: false, active: true, closed_reason: nil)
       (decision_to_reopen || current_decision).update(status: :pending)
       MatchEvents::Reopened.create(match_id: id, contact_id: contact.id)
-      # If this match was picked up in nightly processing, the client now appears as housed in the warehouse,
-      # so clean that up...
-      Warehouse::CasHoused.where(match_id: id).destroy_all
 
-      active_referral_event&.clear if Warehouse::Base.enabled?
+      if Warehouse::Base.enabled?
+        # If this match was picked up in nightly processing, the client now appears as housed in the warehouse,
+        # so clean that up...
+        Warehouse::CasHoused.where(match_id: id).destroy_all
+        active_referral_event&.clear
+      end
     end
   end
 

--- a/app/views/opportunity_matches/_requirements.haml
+++ b/app/views/opportunity_matches/_requirements.haml
@@ -6,7 +6,7 @@
   - requirements = @opportunity.requirements_with_inherited
   - if requirements.count > 0
     - requirements.each do |r|
-      .mb-2{data: { bs_toggle: :tooltip, bs_title: r.rule.description }}
+      .mb-2{data: { bs_toggle: :tooltip, bs_title: r.rule&.description }}
         = r.name
         - if r.variable.present?
           = r.display_for_variable

--- a/app/views/vouchers/_voucher.haml
+++ b/app/views/vouchers/_voucher.haml
@@ -85,9 +85,9 @@
                 - else
                   = match.client_name_for_contact(current_contact, hidden: match.confidential? && ! show_confidential_names?)
         - if (! voucher.can_be_destroyed? && ! voucher.active_matches?) || voucher.opportunity.present?
-          %h3.detail-box--label.mt-4 Alternate Clients
           .detail-box-value
-            - if voucher.opportunity.present?
+            - if voucher.opportunity.present? && voucher.available?
+              %h3.detail-box--label.mt-4 Alternate Clients
               = link_to opportunity_matches_path(voucher.opportunity) do
                 Prioritized Clients
             - if ! voucher.can_be_destroyed? && ! voucher.active_matches?

--- a/spec/models/client_opportunity_match_reopen_spec.rb
+++ b/spec/models/client_opportunity_match_reopen_spec.rb
@@ -127,6 +127,32 @@ RSpec.describe ClientOpportunityMatch, type: :model do
       end
     end
 
+    context 'when the warehouse is not enabled' do
+      # In environments without the warehouse schema (e.g. CI), reopen! must not
+      # touch warehouse tables -- they do not exist there.
+      let(:route) { MatchRoutes::Thirteen.first }
+      let!(:match) do
+        create :client_opportunity_match,
+               match_route: route,
+               active: false,
+               closed: true,
+               closed_reason: 'canceled'
+      end
+
+      before(:each) do
+        set_status(match.thirteen_hearing_outcome_decision, 'canceled')
+        allow(Warehouse::Base).to receive(:enabled?).and_return(false)
+      end
+
+      it 'does not query warehouse tables' do
+        expect(Warehouse::CasHoused).not_to receive(:where)
+
+        match.reopen!(contact)
+
+        expect(match.thirteen_hearing_outcome_decision.reload.status).to eq('pending')
+      end
+    end
+
     context 'on a canceled Default route match' do
       let(:route) { MatchRoutes::Default.first }
       let!(:match) do

--- a/spec/models/client_opportunity_match_reopen_spec.rb
+++ b/spec/models/client_opportunity_match_reopen_spec.rb
@@ -1,0 +1,129 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ClientOpportunityMatch, type: :model do
+  describe '#reopen!' do
+    let(:contact) { create :contact }
+
+    # Set a decision's status directly, bypassing callbacks/validations, so we
+    # can reconstruct a precise historical match state.
+    def set_status(decision, status, administrative_cancel_reason: nil)
+      attrs = { status: status }
+      attrs[:administrative_cancel_reason_id] = administrative_cancel_reason.id if administrative_cancel_reason
+      decision.update_columns(attrs)
+    end
+
+    context 'on a canceled Match Route Thirteen match' do
+      let(:route) { MatchRoutes::Thirteen.first }
+      let!(:match) do
+        create :client_opportunity_match,
+               match_route: route,
+               active: false,
+               closed: true,
+               closed_reason: 'canceled'
+      end
+
+      context 'with a realistic decision chain canceled at the Hearing Outcome step' do
+        # Reproduces the production state from match 412917: the match progressed
+        # normally (leaving Match Acknowledgement permanently `acknowledged`) and
+        # was then canceled at the Hearing Outcome step with a cancel reason.
+        let(:cancel_reason) { MatchDecisionReasons::AdministrativeCancel.create!(name: 'Vacancy filled by other client') }
+
+        before(:each) do
+          set_status(match.thirteen_client_match_decision, 'accepted')
+          set_status(match.thirteen_match_acknowledgement_decision, 'acknowledged')
+          set_status(match.thirteen_client_review_decision, 'accepted')
+          set_status(match.thirteen_hearing_scheduled_decision, 'accepted')
+          set_status(match.thirteen_hearing_outcome_decision, 'canceled', administrative_cancel_reason: cancel_reason)
+        end
+
+        it 'reopens the canceled Hearing Outcome decision' do
+          match.reopen!(contact)
+
+          expect(match.thirteen_hearing_outcome_decision.reload.status).to eq('pending')
+        end
+
+        it 'leaves every earlier decision untouched' do
+          match.reopen!(contact)
+
+          aggregate_failures do
+            expect(match.thirteen_client_match_decision.reload.status).to eq('accepted')
+            expect(match.thirteen_match_acknowledgement_decision.reload.status).to eq('acknowledged')
+            expect(match.thirteen_client_review_decision.reload.status).to eq('accepted')
+            expect(match.thirteen_hearing_scheduled_decision.reload.status).to eq('accepted')
+          end
+        end
+      end
+
+      context 'when an earlier decision lingers in an expiration_update status' do
+        # `expiration_update` is, like `acknowledged`, one of the statuses
+        # current_decision treats as "the active step", so it can mislead reopen
+        # the same way.
+        before(:each) do
+          set_status(match.thirteen_client_match_decision, 'expiration_update')
+          set_status(match.thirteen_match_acknowledgement_decision, 'acknowledged')
+          set_status(match.thirteen_hearing_outcome_decision, 'canceled')
+        end
+
+        it 'reopens the canceled decision and leaves the expiration_update step alone' do
+          match.reopen!(contact)
+
+          aggregate_failures do
+            expect(match.thirteen_hearing_outcome_decision.reload.status).to eq('pending')
+            expect(match.thirteen_client_match_decision.reload.status).to eq('expiration_update')
+            expect(match.thirteen_match_acknowledgement_decision.reload.status).to eq('acknowledged')
+          end
+        end
+      end
+
+      context 'when canceled at the initial step before anything is acknowledged' do
+        before(:each) do
+          set_status(match.thirteen_client_match_decision, 'canceled')
+        end
+
+        it 'reopens the canceled initial decision' do
+          match.reopen!(contact)
+
+          expect(match.thirteen_client_match_decision.reload.status).to eq('pending')
+        end
+      end
+    end
+
+    context 'on a canceled Default route match' do
+      let(:route) { MatchRoutes::Default.first }
+      let!(:match) do
+        create :client_opportunity_match,
+               match_route: route,
+               active: false,
+               closed: true,
+               closed_reason: 'canceled'
+      end
+
+      # Proves the fix is not Route-Thirteen-specific: an earlier
+      # Shelter Agency step left in expiration_update must not be reopened in
+      # place of the later canceled HSA approval step.
+      before(:each) do
+        set_status(match.match_recommendation_dnd_staff_decision, 'accepted')
+        set_status(match.match_recommendation_shelter_agency_decision, 'expiration_update')
+        set_status(match.approve_match_housing_subsidy_admin_decision, 'canceled')
+      end
+
+      it 'reopens the canceled HSA approval decision, not the earlier expiration_update step' do
+        match.reopen!(contact)
+
+        aggregate_failures do
+          expect(match.approve_match_housing_subsidy_admin_decision.reload.status).to eq('pending')
+          expect(match.match_recommendation_shelter_agency_decision.reload.status).to eq('expiration_update')
+          expect(match.match_recommendation_dnd_staff_decision.reload.status).to eq('accepted')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/client_opportunity_match_reopen_spec.rb
+++ b/spec/models/client_opportunity_match_reopen_spec.rb
@@ -31,9 +31,6 @@ RSpec.describe ClientOpportunityMatch, type: :model do
       end
 
       context 'with a realistic decision chain canceled at the Hearing Outcome step' do
-        # Reproduces the production state from match 412917: the match progressed
-        # normally (leaving Match Acknowledgement permanently `acknowledged`) and
-        # was then canceled at the Hearing Outcome step with a cancel reason.
         let(:cancel_reason) { MatchDecisionReasons::AdministrativeCancel.create!(name: 'Vacancy filled by other client') }
 
         before(:each) do

--- a/spec/models/client_opportunity_match_reopen_spec.rb
+++ b/spec/models/client_opportunity_match_reopen_spec.rb
@@ -128,8 +128,11 @@ RSpec.describe ClientOpportunityMatch, type: :model do
     end
 
     context 'when the warehouse is not enabled' do
-      # In environments without the warehouse schema (e.g. CI), reopen! must not
-      # touch warehouse tables -- they do not exist there.
+      # In environments without the warehouse schema (e.g. CI) the warehouse
+      # tables do not exist, so reopen! must not query them. We swap the
+      # warehouse model for a null-object spy via stub_const -- mocking the real
+      # AR class would make its verifying double introspect the missing table,
+      # raising PG::UndefinedTable before reopen! even runs.
       let(:route) { MatchRoutes::Thirteen.first }
       let!(:match) do
         create :client_opportunity_match,
@@ -142,14 +145,16 @@ RSpec.describe ClientOpportunityMatch, type: :model do
       before(:each) do
         set_status(match.thirteen_hearing_outcome_decision, 'canceled')
         allow(Warehouse::Base).to receive(:enabled?).and_return(false)
+        stub_const('Warehouse::CasHoused', spy('Warehouse::CasHoused'))
       end
 
-      it 'does not query warehouse tables' do
-        expect(Warehouse::CasHoused).not_to receive(:where)
-
+      it 'reopens the match without querying the warehouse' do
         match.reopen!(contact)
 
-        expect(match.thirteen_hearing_outcome_decision.reload.status).to eq('pending')
+        aggregate_failures do
+          expect(Warehouse::CasHoused).not_to have_received(:where)
+          expect(match.thirteen_hearing_outcome_decision.reload.status).to eq('pending')
+        end
       end
     end
 

--- a/spec/models/client_opportunity_match_reopen_spec.rb
+++ b/spec/models/client_opportunity_match_reopen_spec.rb
@@ -96,6 +96,40 @@ RSpec.describe ClientOpportunityMatch, type: :model do
       end
     end
 
+    context 'on a successful Match Route Thirteen match' do
+      let(:route) { MatchRoutes::Thirteen.first }
+      let!(:match) do
+        create :client_opportunity_match,
+               match_route: route,
+               active: false,
+               closed: true,
+               closed_reason: 'success'
+      end
+
+      # A fully successful match: it ran all the way through, leaving Match
+      # Acknowledgement permanently `acknowledged` and the final Confirm Match
+      # Success decision `confirmed`.
+      before(:each) do
+        set_status(match.thirteen_client_match_decision, 'accepted')
+        set_status(match.thirteen_match_acknowledgement_decision, 'acknowledged')
+        set_status(match.thirteen_client_review_decision, 'accepted')
+        set_status(match.thirteen_hearing_scheduled_decision, 'accepted')
+        set_status(match.thirteen_hearing_outcome_decision, 'accepted')
+        set_status(match.thirteen_hsa_review_decision, 'accepted')
+        set_status(match.thirteen_accept_referral_decision, 'accepted')
+        set_status(match.thirteen_confirm_match_success_decision, 'confirmed')
+      end
+
+      it 'reopens the success decision, not an earlier acknowledged step' do
+        match.reopen!(contact)
+
+        aggregate_failures do
+          expect(match.thirteen_confirm_match_success_decision.reload.status).to eq('pending')
+          expect(match.thirteen_match_acknowledgement_decision.reload.status).to eq('acknowledged')
+        end
+      end
+    end
+
     context 'on a canceled Default route match' do
       let(:route) { MatchRoutes::Default.first }
       let!(:match) do

--- a/spec/requests/inactive_voucher_hides_activation_spec.rb
+++ b/spec/requests/inactive_voucher_hides_activation_spec.rb
@@ -1,0 +1,100 @@
+###
+# Copyright 2016 - 2025 Green River Data Analysis, LLC
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Activation is hidden when a voucher is unavailable', type: :request do
+  let!(:contact) { create :macbeth }
+  let!(:user) { create :user, contact: contact }
+  let!(:prioritization_scheme) { create :priority_days_homeless }
+  let!(:route) do
+    route = MatchRoutes::Default.first
+    route.update(match_prioritization: prioritization_scheme)
+    route
+  end
+  let!(:match) { create :client_opportunity_match, active: false, match_route: route }
+  let!(:project_client) { create :project_client, client_id: match.client.id }
+  let(:opportunity) { match.opportunity }
+  let(:voucher) { opportunity.voucher }
+
+  before(:each) do
+    sign_in user
+  end
+
+  describe 'the prioritized clients (opportunity matches) page' do
+    let!(:role) do
+      create :role,
+             can_see_all_alternate_matches: true,
+             can_edit_assigned_programs: true,
+             can_view_assigned_programs: true,
+             can_activate_matches: true
+    end
+
+    before(:each) do
+      EntityViewPermission.create(entity: match.program, agency: user.agency, editable: true)
+      user.roles << role
+    end
+
+    context 'when the voucher is available' do
+      it 'shows the activate match controls' do
+        get opportunity_matches_path(opportunity_id: opportunity.id)
+
+        expect(response.body).to include('Activate Match')
+      end
+    end
+
+    context 'when the voucher is not available' do
+      before(:each) { voucher.update!(available: false) }
+
+      it 'hides the activate match controls' do
+        get opportunity_matches_path(opportunity_id: opportunity.id)
+
+        expect(response.body).to_not include('Activate Match')
+      end
+
+      it 'refuses to activate a match via the controller' do
+        expect do
+          patch opportunity_match_path(opportunity, match.client.id)
+        end.to_not(change { opportunity.active_matches.count })
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  describe 'the vouchers index page' do
+    let!(:role) do
+      create :role,
+             can_view_vouchers: true,
+             can_view_assigned_programs: true
+    end
+
+    before(:each) do
+      EntityViewPermission.create(entity: match.program, agency: user.agency, editable: true)
+      user.roles << role
+    end
+
+    context 'when the voucher is available' do
+      it 'shows the Prioritized Clients link' do
+        get program_sub_program_vouchers_path(program_id: match.program.id, sub_program_id: match.sub_program.id)
+
+        expect(response.body).to include('Prioritized Clients')
+      end
+    end
+
+    context 'when the voucher is not available' do
+      before(:each) { voucher.update!(available: false) }
+
+      it 'hides the Prioritized Clients link' do
+        get program_sub_program_vouchers_path(program_id: match.program.id, sub_program_id: match.sub_program.id)
+
+        expect(response.body).to_not include('Prioritized Clients')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Fixes two unrelated issues.
1. When reopening a match, it previously tried to reactivate the `current` step, but the current step calculation doesn't account for canceling a match.  Fixes to use the `success_decision` if the match was successsful and the`unsuccessful_decision` if not.
2. When a voucher is marked as `active` and then later made inactive, the list of prioritized clients still showed on the vouchers page and from the prioritized clients page you could still activate matches.  This hides the link and updates `can_activate_matches?` to return false unless the associated voucher is `active`.


## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* Bug fix 

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
