### PR TITLE
[#9342] JS/CSS fixes

### DIFF
--- a/app/assets/stylesheets/modules/_tables.scss
+++ b/app/assets/stylesheets/modules/_tables.scss
@@ -26,6 +26,11 @@ th[class^="sort-"] {
 .table-responsive span[class*="icon-"] {
   font-size: rem(12);
 }
+
+// Allow dropdown menus to extend outside the scroll container while open.
+.table-responsive:has(.dropdown-menu.show) {
+  overflow: visible;
+}
 .btn-sm span[class^="icon-"],
 .btn-sm span[class*="icon-"],
 .btn-sm span[class^="icon-"],

--- a/app/views/clients/_park_client_form.html.haml
+++ b/app/views/clients/_park_client_form.html.haml
@@ -1,5 +1,5 @@
 .dropdown.c-dropdown
-  %a#park-client-dropdown.btn.btn-sm.btn-secondary.dropdown-toggle{aria: {expanded:  'false', haspopup:  'true'}, data: { bs_toggle:  'dropdown'}, href:  '#', role:  'button'}
+  %a#park-client-dropdown.btn.btn-sm.btn-secondary.dropdown-toggle{aria: {expanded:  'false', haspopup:  'true'}, data: { bs_toggle:  'dropdown', bs_auto_close: 'outside'}, href:  '#', role:  'button'}
     Park Client
   .c-dropdown__menu.c-dropdown__menu--sized.dropdown-menu.dropdown-menu-right.p-4{"aria-labelledby" => "park-client-dropdown"}
     = simple_form_for(@client) do |f|


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

* Fixes the datepicker for parking clients that is within a pop-over.  Previously clicking within the calendar auto closed the pop-over.  Now you have to click outside of the popover to close it.
<img width="467" height="345" alt="Screenshot 2026-06-26 at 7 08 06 PM" src="https://github.com/user-attachments/assets/011887a2-733d-40c8-a267-626a2848b79e" />

* Fixes an issue where the last action menu on the admin user screen was clipped because the table is responsive.
 <img width="858" height="283" alt="Screenshot 2026-06-26 at 7 09 11 PM" src="https://github.com/user-attachments/assets/48d671ac-7fa1-46f9-a19b-5e46e9c31f57" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
