### PR TITLE
[#9343] Only show tooltips on grouped rows

### DIFF
--- a/app/views/match_events/_match_event.haml
+++ b/app/views/match_events/_match_event.haml
@@ -13,7 +13,7 @@
               Edit Note
   %td= event.decision&.step_name
   %td.history--contact-name
-    - tooltip_title = event.contact_names.map { |n| h(n) }.join("<br>").html_safe
+    - tooltip_title = event.contact_names.map { |n| h(n) }.join("<br>").html_safe if event.grouped
     - if tooltip_title.present?
       %span.history--contacts-tooltip{data: {bs_toggle: "tooltip", bs_placement: "top", bs_html: "true", bs_title: tooltip_title}}= event.contact_display
     - else


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

- Adjusts the change to the tooltip presence in the match nistory so we don't show a tooltip with a person's name on their name.


## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
