### PR TITLE
[#9228] Show confirmation language if translated

### DIFF
--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -21,6 +21,11 @@ class Translation < ApplicationRecord
     translated.presence || text
   end
 
+  def self.translated?(text)
+    translated_text = translate(text)
+    translated_text != text
+  end
+
   def self.cache_key(text)
     digest = Digest::MD5.hexdigest(text.to_s)
     "translations/#{digest}"

--- a/app/views/match_decisions/_hsa_acknowledges_receipt.haml
+++ b/app/views/match_decisions/_hsa_acknowledges_receipt.haml
@@ -11,6 +11,9 @@
                 %h3 Acknowledge Match
             .o-choose__content
               - if @decision.status.to_s.in?(['pending', 'expiration_update'])
+                - if Translation.translated?('match shelter agency agreement modal')
+                  %p
+                    = simple_format Translation.translate('match shelter agency agreement modal')
                 %div{data: {acknowledge_href: access_context.match_decision_acknowledgment_path(@match, @decision)}}
                 = render 'match_decisions/continue_button', text: 'Acknowledge Receipt of Match Details', icon: 'checkmark', button_attributes: { class: 'btn btn-success', data: {submit_param_name: 'decision[status]', submit_param_value: 'acknowledged'}, disabled: !(@decision.editable?) }
           - if can_reject_matches?

--- a/app/views/match_decisions/_set_asides_hsa_accepts_client.haml
+++ b/app/views/match_decisions/_set_asides_hsa_accepts_client.haml
@@ -15,7 +15,9 @@
             %p
               %i.icon-info
               If accepted, all involved parties will be notified.
-
+            - if Translation.translated?('match shelter agency agreement modal')
+              %p
+                = simple_format Translation.translate('match shelter agency agreement modal')
             = form.submit 'Accept Match', class: 'btn btn-success jAccept', data: {submit_param_name: 'decision[status]', submit_param_value: 'accepted'}, disabled: (!@decision.editable?)
 
         = render 'match_decisions/decline_and_cancel_actions', form: form, action_message: 'If the match is declined, the DND will be informed of the decision.'


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

* Exposes the confirmation language on initial steps for the Provider Only Route and Homeless Set-Aside Route if the language has been translated
* Adds a method to Translation to check if a string has been translated.


## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [ ] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
