### PR TITLE
9379 de-identified upload enhancement

### DIFF
--- a/app/controllers/deidentified_clients_controller.rb
+++ b/app/controllers/deidentified_clients_controller.rb
@@ -60,23 +60,30 @@ class DeidentifiedClientsController < NonHmisClientsController
   end
 
   def choose_upload
-    @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+    @upload = DeidentifiedClientsXlsx.new
   end
 
   def import
     unless params[:deidentified_clients_xlsx]&.[](:file)
-      @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+      @upload = new_upload_from_params
       flash[:alert] = Translation.translate('You must attach a file in the form.')
       render :choose_upload
       return
     end
 
+    if import_params[:update_availability].blank?
+      @upload = new_upload_from_params
+      flash[:alert] = Translation.translate('You must choose whether to update client availability')
+      render :choose_upload
+      return
+    end
+
     file = import_params[:file]
-    agency = Agency.find(import_params[:agency_id].to_i)
+    agency = DeidentifiedClient.agencies_available_to(current_user).find_by(id: import_params[:agency_id])
     update_availability = import_params[:update_availability].to_s.in?(['1', 'true'])
 
     unless agency.present?
-      @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+      @upload = new_upload_from_params
       flash[:alert] = Translation.translate('You must select a valid agency')
       render :choose_upload
       return
@@ -89,7 +96,7 @@ class DeidentifiedClientsController < NonHmisClientsController
       validation_result = DeidentifiedClientsXlsx.validate_file_content(file_content, file.content_type)
 
       unless validation_result[:valid]
-        @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+        @upload = new_upload_from_params
         flash[:alert] = validation_result[:error]
         render :choose_upload
         return
@@ -103,14 +110,14 @@ class DeidentifiedClientsController < NonHmisClientsController
         content: file_content,
       )
     rescue StandardError
-      @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+      @upload = new_upload_from_params
       flash[:alert] = Translation.translate('Cannot read uploaded file, is it an XLSX?')
       render :choose_upload
       return
     end
 
     unless @upload.valid_header?
-      @upload = DeidentifiedClientsXlsx.new(agency_id: current_user.agency_id)
+      @upload = new_upload_from_params
       flash[:alert] = Translation.translate('Uploaded file does not have the correct header. Incorrect file?')
       render :choose_upload
       return
@@ -292,6 +299,17 @@ class DeidentifiedClientsController < NonHmisClientsController
       :file,
       :agency_id,
       :update_availability,
+    )
+  end
+
+  # Rebuild the upload form object on error without introducing a default agency or
+  # availability choice — preserve only what the user actually submitted so they are
+  # forced to make (or correct) both selections.
+  private def new_upload_from_params
+    submitted = params[:deidentified_clients_xlsx] ? import_params : ActionController::Parameters.new
+    DeidentifiedClientsXlsx.new(
+      agency_id: submitted[:agency_id],
+      update_availability: submitted[:update_availability],
     )
   end
 

--- a/app/models/deidentified_client.rb
+++ b/app/models/deidentified_client.rb
@@ -34,6 +34,18 @@ class DeidentifiedClient < NonHmisClient
     end
   end
 
+  # Agencies the user may enter/edit de-identified clients for. Mirrors the editable_by scope
+  # so bulk roster uploads are restricted to the same agencies as single-record editing.
+  def self.agencies_available_to(user)
+    if user.can_edit_all_clients? || user.can_manage_all_deidentified_clients?
+      Agency.all
+    elsif user.can_manage_deidentified_clients? || user.can_enter_deidentified_clients?
+      pathways_enabled? ? Agency.all : Agency.where(id: user.agency_id)
+    else
+      Agency.none
+    end
+  end
+
   # Search only the client identifier
   scope :text_search, ->(text) do
     return none unless text.present?

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -45,14 +45,11 @@ class DeidentifiedClientsXlsx < ApplicationRecord
     return unless valid_header?
 
     # Internal (non-user) errors are buffered here and reported to Sentry only after the
-    # transaction commits — reporting mid-transaction would flag rows for a run that may still
-    # roll back and persist nothing. On rollback the block below raises out, this flush is
-    # skipped, and the propagating exception is what reaches Sentry instead.
-    deferred_reports = []
+    # transaction commits
+    sentry_queue = []
 
     # Availability is reset up front, so the whole roster must be atomic: a non-recoverable
-    # failure partway through has to roll that reset back rather than leave every client in
-    # the agency stranded as unavailable.
+    # otherwise a failure could leave all clients in the agency unavailable.
     DeidentifiedClient.transaction do
       DeidentifiedClient.where(agency: agency).update_all(available: false) if @update_availability
 
@@ -61,16 +58,12 @@ class DeidentifiedClientsXlsx < ApplicationRecord
 
         row = Hash[file_attributes.keys.zip(raw)]
 
-        # A Home-base ID is globally unique, so look the client up by ID alone — one indexed
-        # query per row, no table-wide preload. If it's already live under a *different* agency
-        # this importer can't claim it: the global :taken validation would make the save
-        # silently fail and the client would appear "ineligible". Skip it cleanly and report it
-        # (once per ID), without leaking which agency owns it.
+        # A Home-base ID is globally unique, so look the client up by ID alone If it's already
+        # live under a *different* agency skip and report it
         client = DeidentifiedClient.find_by(client_identifier: row[:client_identifier]) ||
           DeidentifiedClient.new(agency: agency, client_identifier: row[:client_identifier])
 
         if client.persisted? && client.agency_id != agency&.id
-          # Report each colliding ID once, even if it appears on multiple rows.
           @skipped_identifiers << row[:client_identifier] unless @skipped_identifiers.include?(row[:client_identifier])
           next
         end
@@ -79,13 +72,12 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         cleaned = begin
           clean_row(client, row)
         rescue StandardError => e
-          # clean_row's helpers attach a field-level error before raising — those are expected,
-          # user-correctable data problems that render in the problems table. If nothing was
-          # attached, this is an unexpected/internal failure: a plain rescue would hide it from
-          # Sentry, so buffer it for reporting (as an un-rescued exception would surface) and
-          # still show a row-level message so the user knows which row was dropped.
+          # clean_row's helpers attach a field-level error before raising. Tthose are expected,
+          # user-correctable data problems. But if nothing was attached then this is an
+          # internal failure, report it and show a row-level message so the user knows which row
+          # was dropped.
           if client.errors.empty?
-            deferred_reports << e
+            sentry_queue << e
             client.errors.add(:base, "Could not process row: #{e.message}")
           end
           next
@@ -102,10 +94,9 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         # errors render in import.haml, and don't count it or touch its assessment.
         was_new = client.new_record?
         unless client.update(cleaned)
-          # A false return with no validation errors means a callback halted the save — an
-          # internal condition, not bad user data — so buffer it for Sentry rather than letting
-          # it vanish (no exception is raised, and there is nothing for the user to correct).
-          deferred_reports << "De-identified roster save halted for client #{client.client_identifier}" if client.errors.empty?
+          # A false return with no validation errors means a callback halted the save due to
+          # an internal error, not bad user data
+          sentry_queue << "De-identified roster save halted for client #{client.client_identifier}" if client.errors.empty?
           next
         end
 
@@ -119,14 +110,13 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         client.actively_homeless = assessment.actively_homeless
         assessment = client.update_assessment_from_client(assessment)
         # Validation is skipped (we don't have the CE Event required fields), so a failure here
-        # is a DB-level, non-user-correctable error. Raise loudly and roll the whole import back
-        # rather than leave the client available with a missing/blank assessment.
+        # is a DB-level, non-user-correctable error. Raise loudly and roll back the tx
         assessment.save!(validate: false)
       end
     end
 
-    # Transaction committed — safe to report the internal errors we buffered above.
-    deferred_reports.each do |report|
+    # Transaction committed, report the internal errors
+    sentry_queue.each do |report|
       report.is_a?(Exception) ? Sentry.capture_exception(report) : Sentry.capture_message(report)
     end
   end

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -13,7 +13,7 @@ class DeidentifiedClientsXlsx < ApplicationRecord
   include FileContentValidator
 
   attr_accessor :agency_id, :update_availability
-  attr_reader :added, :touched, :skipped, :skipped_identifiers, :problems, :clients
+  attr_reader :added, :touched, :skipped_identifiers, :problems, :clients
 
   # Validate file content before creating record
   def self.validate_file_content(file_content, claimed_content_type = nil)
@@ -38,7 +38,6 @@ class DeidentifiedClientsXlsx < ApplicationRecord
   def import(agency, update_availability: false)
     @added = 0
     @touched = 0
-    @skipped = 0
     @skipped_identifiers = []
     @clients = []
     @update_availability = update_availability
@@ -51,17 +50,18 @@ class DeidentifiedClientsXlsx < ApplicationRecord
       next if skip?(raw, index)
 
       row = Hash[file_attributes.keys.zip(raw)]
-      client = DeidentifiedClient.where(agency: agency, client_identifier: row[:client_identifier]).first_or_initialize
 
-      # A Home-base ID is globally unique (validation-only), but this importer keys on
-      # (agency, client_identifier). When the same ID is already live under a *different*
-      # agency, the global :taken validation makes the save silently fail — the client never
-      # persists and appears "ineligible". Skip it cleanly and report it, without leaking
-      # which agency owns it.
-      if client.new_record? &&
-         DeidentifiedClient.where(client_identifier: row[:client_identifier]).where.not(agency_id: agency&.id).exists?
-        @skipped += 1
-        @skipped_identifiers << row[:client_identifier]
+      # A Home-base ID is globally unique, so look the client up by ID alone — one indexed
+      # query per row, no table-wide preload. If it's already live under a *different* agency
+      # this importer can't claim it: the global :taken validation would make the save
+      # silently fail and the client would appear "ineligible". Skip it cleanly and report it
+      # (once per ID), without leaking which agency owns it.
+      client = DeidentifiedClient.find_by(client_identifier: row[:client_identifier]) ||
+        DeidentifiedClient.new(agency: agency, client_identifier: row[:client_identifier])
+
+      if client.persisted? && client.agency_id != agency&.id
+        # Report each colliding ID once, even if it appears on multiple rows.
+        @skipped_identifiers << row[:client_identifier] unless @skipped_identifiers.include?(row[:client_identifier])
         next
       end
 

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -44,56 +44,90 @@ class DeidentifiedClientsXlsx < ApplicationRecord
 
     return unless valid_header?
 
-    DeidentifiedClient.where(agency: agency).update_all(available: false) if @update_availability
+    # Internal (non-user) errors are buffered here and reported to Sentry only after the
+    # transaction commits — reporting mid-transaction would flag rows for a run that may still
+    # roll back and persist nothing. On rollback the block below raises out, this flush is
+    # skipped, and the propagating exception is what reaches Sentry instead.
+    deferred_reports = []
 
-    @xlsx.each_with_index do |raw, index|
-      next if skip?(raw, index)
+    # Availability is reset up front, so the whole roster must be atomic: a non-recoverable
+    # failure partway through has to roll that reset back rather than leave every client in
+    # the agency stranded as unavailable.
+    DeidentifiedClient.transaction do
+      DeidentifiedClient.where(agency: agency).update_all(available: false) if @update_availability
 
-      row = Hash[file_attributes.keys.zip(raw)]
+      @xlsx.each_with_index do |raw, index|
+        next if skip?(raw, index)
 
-      # A Home-base ID is globally unique, so look the client up by ID alone — one indexed
-      # query per row, no table-wide preload. If it's already live under a *different* agency
-      # this importer can't claim it: the global :taken validation would make the save
-      # silently fail and the client would appear "ineligible". Skip it cleanly and report it
-      # (once per ID), without leaking which agency owns it.
-      client = DeidentifiedClient.find_by(client_identifier: row[:client_identifier]) ||
-        DeidentifiedClient.new(agency: agency, client_identifier: row[:client_identifier])
+        row = Hash[file_attributes.keys.zip(raw)]
 
-      if client.persisted? && client.agency_id != agency&.id
-        # Report each colliding ID once, even if it appears on multiple rows.
-        @skipped_identifiers << row[:client_identifier] unless @skipped_identifiers.include?(row[:client_identifier])
-        next
+        # A Home-base ID is globally unique, so look the client up by ID alone — one indexed
+        # query per row, no table-wide preload. If it's already live under a *different* agency
+        # this importer can't claim it: the global :taken validation would make the save
+        # silently fail and the client would appear "ineligible". Skip it cleanly and report it
+        # (once per ID), without leaking which agency owns it.
+        client = DeidentifiedClient.find_by(client_identifier: row[:client_identifier]) ||
+          DeidentifiedClient.new(agency: agency, client_identifier: row[:client_identifier])
+
+        if client.persisted? && client.agency_id != agency&.id
+          # Report each colliding ID once, even if it appears on multiple rows.
+          @skipped_identifiers << row[:client_identifier] unless @skipped_identifiers.include?(row[:client_identifier])
+          next
+        end
+
+        @clients << client
+        cleaned = begin
+          clean_row(client, row)
+        rescue StandardError => e
+          # clean_row's helpers attach a field-level error before raising — those are expected,
+          # user-correctable data problems that render in the problems table. If nothing was
+          # attached, this is an unexpected/internal failure: a plain rescue would hide it from
+          # Sentry, so buffer it for reporting (as an un-rescued exception would surface) and
+          # still show a row-level message so the user knows which row was dropped.
+          if client.errors.empty?
+            deferred_reports << e
+            client.errors.add(:base, "Could not process row: #{e.message}")
+          end
+          next
+        end
+
+        cleaned[:agency_id] = agency&.id
+        cleaned[:identified] = false # mark as de-identified client
+        if @update_availability
+          cleaned[:available] = true
+          cleaned[:actively_homeless] = true
+        end
+
+        # A failed save is user-correctable bad data: leave the client in @clients so its
+        # errors render in import.haml, and don't count it or touch its assessment.
+        was_new = client.new_record?
+        unless client.update(cleaned)
+          # A false return with no validation errors means a callback halted the save — an
+          # internal condition, not bad user data — so buffer it for Sentry rather than letting
+          # it vanish (no exception is raised, and there is nothing for the user to correct).
+          deferred_reports << "De-identified roster save halted for client #{client.client_identifier}" if client.errors.empty?
+          next
+        end
+
+        was_new ? (@added += 1) : (@touched += 1)
+
+        assessment = client.current_assessment
+        assessment.actively_homeless = true if @update_availability
+        assessment_type = Config.get(:deidentified_client_assessment) || 'DeidentifiedClientAssessment'
+        assessment = build_assessment(client, agency, assessment_type) if assessment.nil? || assessment.class.name != assessment_type
+        # maintain current active status
+        client.actively_homeless = assessment.actively_homeless
+        assessment = client.update_assessment_from_client(assessment)
+        # Validation is skipped (we don't have the CE Event required fields), so a failure here
+        # is a DB-level, non-user-correctable error. Raise loudly and roll the whole import back
+        # rather than leave the client available with a missing/blank assessment.
+        assessment.save!(validate: false)
       end
+    end
 
-      @clients << client
-      cleaned = begin
-        clean_row(client, row)
-      rescue StandardError
-        next
-      end
-
-      cleaned[:agency_id] = agency&.id
-      cleaned[:identified] = false # mark as de-identified client
-      if @update_availability
-        cleaned[:available] = true
-        cleaned[:actively_homeless] = true
-      end
-
-      # Count and run the assessment block only on a successful save; a failed save leaves
-      # the client in @clients so its errors render in import.haml.
-      was_new = client.new_record?
-      next unless client.update(cleaned)
-
-      was_new ? (@added += 1) : (@touched += 1)
-
-      assessment = client.current_assessment
-      assessment.actively_homeless = true if @update_availability
-      assessment_type = Config.get(:deidentified_client_assessment) || 'DeidentifiedClientAssessment'
-      assessment = build_assessment(client, agency, assessment_type) if assessment.nil? || assessment.class.name != assessment_type
-      # maintain current active status
-      client.actively_homeless = assessment.actively_homeless
-      assessment = client.update_assessment_from_client(assessment)
-      assessment.save(validate: false) # We don't have the CE Event required fields
+    # Transaction committed — safe to report the internal errors we buffered above.
+    deferred_reports.each do |report|
+      report.is_a?(Exception) ? Sentry.capture_exception(report) : Sentry.capture_message(report)
     end
   end
 

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -72,7 +72,7 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         cleaned = begin
           clean_row(client, row)
         rescue StandardError => e
-          # clean_row's helpers attach a field-level error before raising. Tthose are expected,
+          # clean_row's helpers attach a field-level error before raising. Those are expected,
           # user-correctable data problems. But if nothing was attached then this is an
           # internal failure, report it and show a row-level message so the user knows which row
           # was dropped.

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -13,7 +13,7 @@ class DeidentifiedClientsXlsx < ApplicationRecord
   include FileContentValidator
 
   attr_accessor :agency_id, :update_availability
-  attr_reader :added, :touched, :problems, :clients
+  attr_reader :added, :touched, :skipped, :skipped_identifiers, :problems, :clients
 
   # Validate file content before creating record
   def self.validate_file_content(file_content, claimed_content_type = nil)
@@ -38,6 +38,8 @@ class DeidentifiedClientsXlsx < ApplicationRecord
   def import(agency, update_availability: false)
     @added = 0
     @touched = 0
+    @skipped = 0
+    @skipped_identifiers = []
     @clients = []
     @update_availability = update_availability
 
@@ -50,6 +52,19 @@ class DeidentifiedClientsXlsx < ApplicationRecord
 
       row = Hash[file_attributes.keys.zip(raw)]
       client = DeidentifiedClient.where(agency: agency, client_identifier: row[:client_identifier]).first_or_initialize
+
+      # A Home-base ID is globally unique (validation-only), but this importer keys on
+      # (agency, client_identifier). When the same ID is already live under a *different*
+      # agency, the global :taken validation makes the save silently fail — the client never
+      # persists and appears "ineligible". Skip it cleanly and report it, without leaking
+      # which agency owns it.
+      if client.new_record? &&
+         DeidentifiedClient.where(client_identifier: row[:client_identifier]).where.not(agency_id: agency&.id).exists?
+        @skipped += 1
+        @skipped_identifiers << row[:client_identifier]
+        next
+      end
+
       @clients << client
       cleaned = begin
         clean_row(client, row)
@@ -64,9 +79,12 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         cleaned[:actively_homeless] = true
       end
 
-      @added += 1 if client.updated_at.nil?
-      @touched += 1 if client.updated_at.present?
-      client.update(cleaned)
+      # Count and run the assessment block only on a successful save; a failed save leaves
+      # the client in @clients so its errors render in import.haml.
+      was_new = client.new_record?
+      next unless client.update(cleaned)
+
+      was_new ? (@added += 1) : (@touched += 1)
 
       assessment = client.current_assessment
       assessment.actively_homeless = true if @update_availability

--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -24,8 +24,8 @@ class DeidentifiedClientsXlsx < ApplicationRecord
     super(file_content, claimed_content_type, allowed_types, '.xlsx')
   end
 
-  def agency_options_for_select
-    Agency.order(name: :asc).pluck(:name, :id).to_h
+  def agency_options_for_select(user)
+    DeidentifiedClient.agencies_available_to(user).order(name: :asc).pluck(:name, :id).to_h
   end
 
   def valid_header?

--- a/app/views/deidentified_clients/choose_upload.haml
+++ b/app/views/deidentified_clients/choose_upload.haml
@@ -13,8 +13,8 @@
     = simple_form_for @upload, url: import_deidentified_clients_path, method: :post do |f|
       = f.error_notification
       .form-inputs
-        = f.input :file, as: :file, label: false
-        = f.input :agency_id, as: :select_2, collection: @upload.agency_options_for_select, required: true
-        = f.input :update_availability, as: :boolean, label: 'Update client availability', hint: 'Make only the clients in the selected agency that appear in the selected file available'
+        = f.input :file, as: :file, label: false, required: true
+        = f.input :agency_id, as: :select_2, collection: @upload.agency_options_for_select(current_user), include_blank: 'Select an agency', required: true
+        = f.input :update_availability, as: :radio_buttons, collection: [['Yes', true], ['No', false]], label: 'Update client availability', hint: 'Make only the clients in the selected agency that appear in the selected file available', required: true
       .form-actions
         = f.button :submit, value: 'Upload Excel'

--- a/app/views/deidentified_clients/import.haml
+++ b/app/views/deidentified_clients/import.haml
@@ -9,8 +9,8 @@
   %li= "#{@upload.added} new clients added"
   %li= "#{@upload.touched} existing clients updated"
   %li= "#{problems} records with problems"
-  - if @upload.skipped.to_i > 0
-    %li= "#{@upload.skipped} clients skipped — their ID is already registered to another agency"
+  - if @upload.skipped_identifiers.present?
+    %li= "#{@upload.skipped_identifiers.size} clients skipped — their ID is already registered to another agency"
     %ul
       - @upload.skipped_identifiers.each do |identifier|
         %li= identifier

--- a/app/views/deidentified_clients/import.haml
+++ b/app/views/deidentified_clients/import.haml
@@ -9,6 +9,11 @@
   %li= "#{@upload.added} new clients added"
   %li= "#{@upload.touched} existing clients updated"
   %li= "#{problems} records with problems"
+  - if @upload.skipped.to_i > 0
+    %li= "#{@upload.skipped} clients skipped — their ID is already registered to another agency"
+    %ul
+      - @upload.skipped_identifiers.each do |identifier|
+        %li= identifier
 
 - if problems > 0
   .row

--- a/spec/controllers/deidentified_clients_controller_import_spec.rb
+++ b/spec/controllers/deidentified_clients_controller_import_spec.rb
@@ -1,0 +1,74 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeidentifiedClientsController, type: :controller do
+  let!(:own_agency) { create(:agency, name: 'Own Agency') }
+  let!(:other_agency) { create(:agency, name: 'Other Agency') }
+  let!(:role) { create(:role, can_enter_deidentified_clients: true) }
+  let!(:user) do
+    u = create(:user, agency: own_agency)
+    u.roles << role
+    u
+  end
+
+  let(:xlsx_upload) do
+    Rack::Test::UploadedFile.new(
+      Rails.root.join('spec/fixtures/deidentified_client_xlsxs/initial.xlsx'),
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    )
+  end
+
+  before do
+    authenticate user
+    # Restrict an own-agency enterer to their own agency (mirrors editable_by).
+    allow(DeidentifiedClient).to receive(:pathways_enabled?).and_return(false)
+  end
+
+  describe 'POST #import' do
+    it 'rejects an agency outside the agencies available to the user' do
+      expect do
+        post :import, params: {
+          deidentified_clients_xlsx: {
+            file: xlsx_upload,
+            agency_id: other_agency.id,
+            update_availability: 'true',
+          },
+        }
+      end.not_to change(DeidentifiedClient, :count)
+
+      expect(flash[:alert]).to eq('You must select a valid agency')
+      expect(response).to render_template(:choose_upload)
+    end
+
+    it 'rejects a submission that omits the availability choice' do
+      post :import, params: {
+        deidentified_clients_xlsx: {
+          file: xlsx_upload,
+          agency_id: own_agency.id,
+        },
+      }
+
+      expect(flash[:alert]).to eq('You must choose whether to update client availability')
+      expect(response).to render_template(:choose_upload)
+    end
+
+    it 'rejects a submission with no file attached' do
+      post :import, params: {
+        deidentified_clients_xlsx: {
+          agency_id: own_agency.id,
+          update_availability: 'true',
+        },
+      }
+
+      expect(flash[:alert]).to eq('You must attach a file in the form.')
+      expect(response).to render_template(:choose_upload)
+    end
+  end
+end

--- a/spec/models/deidentified_client_spec.rb
+++ b/spec/models/deidentified_client_spec.rb
@@ -14,4 +14,38 @@ RSpec.describe DeidentifiedClient, type: :model do
                   :can_manage_all_deidentified_clients,
                   :can_manage_deidentified_clients,
                   :can_enter_deidentified_clients
+
+  describe '.agencies_available_to' do
+    let(:own_agency) { create :agency }
+    let(:other_agency) { create :agency }
+    let(:role) { create :role }
+    let(:user) do
+      u = create(:user, agency: own_agency)
+      u.roles << role
+      u
+    end
+
+    before { other_agency } # ensure a second agency exists to be excluded/included
+
+    it 'returns all agencies for a cross-agency manager' do
+      role.update(can_manage_all_deidentified_clients: true)
+      expect(described_class.agencies_available_to(user)).to include(own_agency, other_agency)
+    end
+
+    it 'returns only the user agency for an own-agency enterer (non-pathways)' do
+      role.update(can_enter_deidentified_clients: true)
+      allow(described_class).to receive(:pathways_enabled?).and_return(false)
+      expect(described_class.agencies_available_to(user)).to contain_exactly(own_agency)
+    end
+
+    it 'returns all agencies for an own-agency enterer when pathways is enabled' do
+      role.update(can_enter_deidentified_clients: true)
+      allow(described_class).to receive(:pathways_enabled?).and_return(true)
+      expect(described_class.agencies_available_to(user)).to include(own_agency, other_agency)
+    end
+
+    it 'returns no agencies for a user without de-identified permissions' do
+      expect(described_class.agencies_available_to(user)).to be_empty
+    end
+  end
 end

--- a/spec/models/deidentified_clients_xlsx_spec.rb
+++ b/spec/models/deidentified_clients_xlsx_spec.rb
@@ -1,0 +1,53 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeidentifiedClientsXlsx, type: :model do
+  let(:agency_a) { create :agency }
+  let(:agency_b) { create :agency }
+  let(:home_base_id) { 'HB-0427X' }
+  # order per file_attributes: shelter_location, disabling_condition, client_identifier,
+  # substance_abuse, mental_health, occurrences, days_homeless, family_member, sixty_plus,
+  # is_currently_youth, chronic_homeless, pregnancy, veteran, hiv_aids, health_prioritized
+  let(:row) { ['1', 'No', home_base_id, 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'No', 'No', 'No'] }
+  let(:content) { build_xlsx([row]) }
+
+  it 'skips a Home-base ID already registered to another agency (no silent drop, no duplicate)' do
+    a = DeidentifiedClientsXlsx.new(content: content)
+    a.import(agency_a, update_availability: true)
+    expect(a.added).to eq(1)
+    expect(DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)).to be_present
+
+    b = DeidentifiedClientsXlsx.new(content: content)
+    b.import(agency_b, update_availability: true)
+    expect(b.skipped).to eq(1)
+    expect(b.added).to eq(0)
+    expect(b.skipped_identifiers).to include(home_base_id)
+    expect(DeidentifiedClient.where(client_identifier: home_base_id).count).to eq(1)
+  end
+
+  it 'updates in place on a same-agency re-upload' do
+    DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: true)
+    again = DeidentifiedClientsXlsx.new(content: content)
+    again.import(agency_a, update_availability: true)
+    expect(again.touched).to eq(1)
+    expect(again.skipped).to eq(0)
+    expect(DeidentifiedClient.where(agency: agency_a, client_identifier: home_base_id).count).to eq(1)
+  end
+
+  def build_xlsx(rows)
+    headers = DeidentifiedClientsXlsx.file_header
+    pkg = Axlsx::Package.new
+    pkg.workbook.add_worksheet do |sheet|
+      sheet.add_row(headers)
+      rows.each { |r| sheet.add_row(r, types: Array.new(r.length, :string)) }
+    end
+    pkg.to_stream.read
+  end
+end

--- a/spec/models/deidentified_clients_xlsx_spec.rb
+++ b/spec/models/deidentified_clients_xlsx_spec.rb
@@ -26,10 +26,18 @@ RSpec.describe DeidentifiedClientsXlsx, type: :model do
 
     b = DeidentifiedClientsXlsx.new(content: content)
     b.import(agency_b, update_availability: true)
-    expect(b.skipped).to eq(1)
     expect(b.added).to eq(0)
-    expect(b.skipped_identifiers).to include(home_base_id)
+    expect(b.skipped_identifiers).to contain_exactly(home_base_id)
     expect(DeidentifiedClient.where(client_identifier: home_base_id).count).to eq(1)
+  end
+
+  it 'reports a colliding ID once even when it appears on multiple rows' do
+    DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: true)
+
+    multi = DeidentifiedClientsXlsx.new(content: build_xlsx([row, row]))
+    multi.import(agency_b, update_availability: true)
+
+    expect(multi.skipped_identifiers).to eq([home_base_id])
   end
 
   it 'updates in place on a same-agency re-upload' do

--- a/spec/models/deidentified_clients_xlsx_spec.rb
+++ b/spec/models/deidentified_clients_xlsx_spec.rb
@@ -37,8 +37,60 @@ RSpec.describe DeidentifiedClientsXlsx, type: :model do
     again = DeidentifiedClientsXlsx.new(content: content)
     again.import(agency_a, update_availability: true)
     expect(again.touched).to eq(1)
-    expect(again.skipped).to eq(0)
     expect(DeidentifiedClient.where(agency: agency_a, client_identifier: home_base_id).count).to eq(1)
+  end
+
+  it 'marks imported clients available and actively homeless when update_availability is set' do
+    # Start from the ineligible state so the assertion fails if the importer stops
+    # re-setting availability. update_availability first flips the whole agency to
+    # available: false, then the matching row must flip it back to true.
+    existing = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: home_base_id,
+      available: false,
+      actively_homeless: false,
+    )
+
+    importer = DeidentifiedClientsXlsx.new(content: content)
+    importer.import(agency_a, update_availability: true)
+
+    expect(importer.touched).to eq(1)
+    existing.reload
+    expect(existing.available).to eq(true)
+    expect(existing.actively_homeless).to eq(true)
+  end
+
+  it 'marks previously-available clients absent from the new roster as unavailable' do
+    dropped = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'NOT-IN-FILE',
+      available: true,
+      actively_homeless: true,
+    )
+
+    DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: true)
+
+    # The uploaded roster only contains home_base_id, so the dropped client loses eligibility.
+    expect(dropped.reload.available).to eq(false)
+    expect(DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)&.available).to eq(true)
+  end
+
+  it 'converts roster columns into the correct eligibility and special-population fields' do
+    importer = DeidentifiedClientsXlsx.new(content: content)
+    importer.import(agency_a, update_availability: true)
+    expect(importer.added).to eq(1)
+
+    client = DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)
+    # Each assertion below asserts a non-default value, so it fails if the mapping is
+    # dropped or inverted. yes/no columns whose value ('No') equals the column default
+    # are omitted: they re-exercise one branch and can't fail on a dropped assignment.
+    expect(client.family_member).to eq(true)                 # 'Yes' -> true (yes-branch)
+    expect(client.sixty_plus).to eq(false)                   # 'No'  -> false (no-branch; column default is nil)
+    expect(client.calculated_chronic_homelessness).to eq(1)  # 'Yes' -> 1 (catches the ? 1 : 0 flip)
+    expect(client.days_homeless).to eq(240)                  # numeric conversion
+    expect(client.last_name).to eq("Anonymous - #{home_base_id}")
   end
 
   def build_xlsx(rows)

--- a/spec/models/deidentified_clients_xlsx_spec.rb
+++ b/spec/models/deidentified_clients_xlsx_spec.rb
@@ -40,6 +40,72 @@ RSpec.describe DeidentifiedClientsXlsx, type: :model do
     expect(multi.skipped_identifiers).to eq([home_base_id])
   end
 
+  it 'reports a row with bad data instead of silently dropping it, and still imports the good rows' do
+    bad_row = ['1', 'MAYBE', 'HB-BAD', 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'No', 'No', 'No']
+    importer = DeidentifiedClientsXlsx.new(content: build_xlsx([row, bad_row]))
+    importer.import(agency_a, update_availability: true)
+
+    expect(importer.added).to eq(1) # only the good row counted
+    expect(DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)).to be_present
+
+    failed = importer.clients.detect { |c| c.client_identifier == 'HB-BAD' }
+    expect(failed).to be_present
+    expect(failed.errors).to be_present # surfaces in import.haml's problems table
+    expect(DeidentifiedClient.find_by(client_identifier: 'HB-BAD')).to be_nil
+  end
+
+  it 'raises and rolls the whole import back on a non-user-correctable save failure' do
+    existing = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'ALREADY-HERE',
+      available: true,
+      actively_homeless: true,
+    )
+
+    # Simulate a DB-level failure while persisting the assessment (validation is skipped for
+    # these, so only a hard error can occur here).
+    allow_any_instance_of(DeidentifiedClientAssessment).to receive(:save!).and_raise(ActiveRecord::StatementInvalid, 'boom')
+
+    importer = DeidentifiedClientsXlsx.new(content: content)
+    expect { importer.import(agency_a, update_availability: true) }.to raise_error(ActiveRecord::StatementInvalid)
+
+    # The up-front availability reset must be rolled back, and the new roster client must not persist.
+    expect(existing.reload.available).to eq(true)
+    expect(DeidentifiedClient.find_by(client_identifier: home_base_id)).to be_nil
+  end
+
+  it 'reports an unexpected internal error to Sentry after the transaction commits' do
+    importer = DeidentifiedClientsXlsx.new(content: content)
+    # An unexpected failure in row processing that attaches no user-facing error.
+    allow(importer).to receive(:clean_row).and_raise(RuntimeError, 'kaboom')
+
+    expect(Sentry).to receive(:capture_exception).with(instance_of(RuntimeError))
+
+    importer.import(agency_a, update_availability: true)
+    # The row could not be processed, so nothing was imported, but the run still committed.
+    expect(importer.added).to eq(0)
+  end
+
+  it 'does not report buffered internal errors to Sentry when the transaction rolls back' do
+    # First row hits an unexpected error (would be buffered); second row forces a hard rollback.
+    first_id = 'HB-FIRST'
+    first_row = ['1', 'No', first_id, 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'No', 'No', 'No']
+    importer = DeidentifiedClientsXlsx.new(content: build_xlsx([first_row, row]))
+
+    allow(importer).to receive(:clean_row).and_wrap_original do |original, client, row_hash|
+      raise 'kaboom' if row_hash[:client_identifier] == first_id
+
+      original.call(client, row_hash)
+    end
+    allow_any_instance_of(DeidentifiedClientAssessment).to receive(:save!).and_raise(ActiveRecord::StatementInvalid, 'boom')
+
+    # The buffered first-row error must NOT be flushed, because its transaction rolled back.
+    expect(Sentry).not_to receive(:capture_exception)
+
+    expect { importer.import(agency_a, update_availability: true) }.to raise_error(ActiveRecord::StatementInvalid)
+  end
+
   it 'updates in place on a same-agency re-upload' do
     DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: true)
     again = DeidentifiedClientsXlsx.new(content: content)
@@ -83,6 +149,22 @@ RSpec.describe DeidentifiedClientsXlsx, type: :model do
     # The uploaded roster only contains home_base_id, so the dropped client loses eligibility.
     expect(dropped.reload.available).to eq(false)
     expect(DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)&.available).to eq(true)
+  end
+
+  it 'leaves existing availability untouched when update_availability is not set' do
+    # A client already available but absent from the uploaded roster. With update_availability
+    # off there is no up-front reset, so this client must stay available rather than be de-listed.
+    dropped = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'NOT-IN-FILE',
+      available: true,
+      actively_homeless: true,
+    )
+
+    DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: false)
+
+    expect(dropped.reload.available).to eq(true)
   end
 
   it 'converts roster columns into the correct eligibility and special-population fields' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

### Changes

[See Issue](https://github.com/open-path/Green-River/issues/9379#issuecomment-4942271389)

- **Cross-agency ID collisions.** Client identifiers are globally unique. When an uploaded ID already belonged to another agency, the save failed the uniqueness validation silently, so the client looked ineligible and stayed on the wrong agency. The importer now looks up by ID, skips those rows, and reports the skipped IDs to the user.
- **Atomic availability reset.** The "update availability" reset (mark all agency clients unavailable, then re-activate those in the file) now runs in a single transaction, so a mid-import failure rolls back instead of stranding clients as unavailable or leaving stale ones active.
- **Upload form.** Agency and availability are now explicit required selections (availability is a Yes/No radio; agency defaults to blank rather than the uploader's own agency). The agency list is restricted to agencies the user may edit, mirroring single-record permissions. Errors re-render preserving only submitted values.
- **Error reporting.** Internal failures are reported to Sentry instead of being swallowed; user-correctable data problems still render in the per-row problems table.

## Type of change
Bug fix, New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
