### PR TITLE
[#9393] Vacancy submission feedback

### DIFF
--- a/app/controllers/admin/housing_attribute_names_controller.rb
+++ b/app/controllers/admin/housing_attribute_names_controller.rb
@@ -1,0 +1,74 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module Admin
+  class HousingAttributeNamesController < ApplicationController
+    before_action :require_can_manage_config!
+    before_action :set_row, only: [:edit, :update]
+
+    def index
+      @names = HousingAttribute.name_summary
+    end
+
+    def edit
+      @rows = HousingAttribute.where(name: @row.name, include_value: @row.include_value).
+        includes(:housingable).order(:housingable_type, :housingable_id)
+      @values = @row.include_value? ? HousingAttribute.value_summary(@row.name) : []
+    end
+
+    def update
+      old_name = @row.name
+      new_name = attribute_params[:name].presence || old_name
+
+      HousingAttribute.rename(old_name: old_name, new_name: new_name, include_value: @row.include_value)
+
+      if @row.include_value?
+        Array(attribute_params[:value_renames]).each do |pair|
+          HousingAttribute.rename_value(name: new_name, old_value: pair[:old_value], new_value: pair[:new_value])
+        end
+      end
+
+      flash[:notice] = new_name == old_name ? "Updated '#{new_name}'" : "Renamed '#{old_name}' to '#{new_name}'"
+      redirect_to edit_admin_housing_attribute_name_path(@row.id)
+    end
+
+    private
+
+    def set_row
+      @row = HousingAttribute.find(params[:id].to_i)
+    end
+
+    def attribute_params
+      params.require(:housing_attribute_name).permit(:name, value_renames: [:old_value, :new_value])
+    end
+
+    def housingable_type(housingable)
+      case housingable
+      when Building then 'Building'
+      when Unit then 'Unit'
+      end
+    end
+    helper_method :housingable_type
+
+    def housingable_name(housingable)
+      case housingable
+      when Building then housingable.name
+      when Unit then "#{housingable.name} (#{housingable.building&.name})"
+      end
+    end
+    helper_method :housingable_name
+
+    def housingable_edit_path(housingable)
+      case housingable
+      when Building then edit_building_path(housingable)
+      when Unit then edit_unit_path(housingable)
+      end
+    end
+    helper_method :housingable_edit_path
+  end
+end

--- a/app/controllers/vacancy_submissions_controller.rb
+++ b/app/controllers/vacancy_submissions_controller.rb
@@ -37,14 +37,14 @@ class VacancySubmissionsController < ApplicationController
   before_action :load_resubmittable_submission, only: [:edit, :update]
 
   def index
-    @search_string = params[:q]
     @vacancy_submissions = VacancySubmission
-      .filtered(search: params[:q], status_filter: params[:status])
+      .filtered(program_id: params[:program_id], status_filter: params[:status])
       .order(updated_at: :desc)
       .page(params[:page]).per(25)
 
     program_ids = @vacancy_submissions.map(&:program_id).uniq.compact
     @programs_by_id = Program.where(id: program_ids).index_by(&:id)
+    @programs = Program.where(id: VacancySubmission.program_ids_in_use).order(:name).pluck(:name, :id)
   end
 
   def show

--- a/app/models/concerns/inherits_requirements_from_services.rb
+++ b/app/models/concerns/inherits_requirements_from_services.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
-# Most things with inherited rules only inherit
+# Most things with inherited requirements only inherit
 # from services, so the common code is here
 module InheritsRequirementsFromServices
   extend ActiveSupport::Concern

--- a/app/models/concerns/inherits_requirements_from_services.rb
+++ b/app/models/concerns/inherits_requirements_from_services.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Most things with inherited requirements only inherit
 # from services, so the common code is here
 module InheritsRequirementsFromServices
@@ -22,8 +24,7 @@ module InheritsRequirementsFromServices
 
   module ClassMethods
     def preload_inherited_service_requirements
-      preload services: {requirements: :rules}
+      preload services: { requirements: :rules }
     end
   end
-
 end

--- a/app/models/concerns/inherits_requirements_from_services_only.rb
+++ b/app/models/concerns/inherits_requirements_from_services_only.rb
@@ -4,7 +4,7 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
-# Most things with inherited rules only inherit
+# Most things with inherited requirements only inherit
 # from services, so the common code is here
 module InheritsRequirementsFromServicesOnly
   extend ActiveSupport::Concern

--- a/app/models/concerns/inherits_requirements_from_services_only.rb
+++ b/app/models/concerns/inherits_requirements_from_services_only.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 # Most things with inherited requirements only inherit
 # from services, so the common code is here
 module InheritsRequirementsFromServicesOnly
@@ -19,5 +21,4 @@ module InheritsRequirementsFromServicesOnly
       preload_inherited_service_requirements
     end
   end
-
 end

--- a/app/models/housing_attribute.rb
+++ b/app/models/housing_attribute.rb
@@ -32,6 +32,42 @@ class HousingAttribute < ApplicationRecord
     end.tap { |h| h.each_value { |vals| vals.sort!.uniq! } }
   end
 
+  def self.name_summary
+    counts = group(:name, :include_value).count
+    representative_ids = group(:name, :include_value).minimum(:id)
+
+    counts.map do |(name, include_value), count|
+      OpenStruct.new(
+        name: name,
+        type: include_value ? 'Attribute' : 'Amenity',
+        count: count,
+        id: representative_ids[[name, include_value]],
+      )
+    end.sort_by { |n| [n.name.to_s.downcase, n.type] }
+  end
+
+  def self.value_summary(name)
+    where(name: name).with_value.group(:value).count.
+      sort_by { |value, _| value.to_s }.
+      map { |value, count| OpenStruct.new(value: value, count: count) }
+  end
+
+  def self.rename(old_name:, new_name:, include_value:)
+    return if new_name.blank? || new_name == old_name
+
+    transaction do
+      where(name: old_name, include_value: include_value).find_each { |ha| ha.update!(name: new_name) }
+    end
+  end
+
+  def self.rename_value(name:, old_value:, new_value:)
+    return if old_value.blank? || new_value.blank? || old_value == new_value
+
+    transaction do
+      where(name: name, value: old_value).with_value.find_each { |ha| ha.update!(value: new_value) }
+    end
+  end
+
   def existing_values(for_attribute: nil)
     for_attribute ||= name
     return [] if for_attribute.blank?

--- a/app/models/vacancy_submission.rb
+++ b/app/models/vacancy_submission.rb
@@ -61,9 +61,9 @@ class VacancySubmission < ApplicationRecord
   scope :queue,     -> { where(status: REVIEW_QUEUE_STATUSES) }
   scope :by_status, ->(s) { where(status: s) }
 
-  def self.filtered(search:, status_filter:)
+  def self.filtered(program_id:, status_filter:)
     scope = all
-    scope = scope.where('draft_data::text ILIKE ?', "%#{ActiveRecord::Base.sanitize_sql_like(search)}%") if search.present?
+    scope = scope.where("draft_data ->> 'program_id' = ?", program_id.to_s) if program_id.present?
     case status_filter.to_s
     when 'queue', ''
       scope.queue
@@ -72,6 +72,10 @@ class VacancySubmission < ApplicationRecord
     else
       scope.by_status(status_filter)
     end
+  end
+
+  def self.program_ids_in_use
+    distinct.pluck(Arel.sql("(draft_data ->> 'program_id')::integer")).compact
   end
 
   def self.derive_route(sub_program)

--- a/app/views/admin/housing_attribute_names/edit.haml
+++ b/app/views/admin/housing_attribute_names/edit.haml
@@ -1,0 +1,49 @@
+- type_label = @row.include_value? ? 'Attribute' : 'Amenity'
+- title = "Edit #{type_label} '#{@row.name}'"
+- content_for :title, title
+= render 'menus/admin_tabs'
+%h1= content_for :title
+
+.row.mb-4
+  .col-sm-6
+    = simple_form_for :housing_attribute_name, url: admin_housing_attribute_name_path(@row.id), method: :patch do |f|
+      .form-inputs
+        = f.input :name, label: 'Attribute name', input_html: { value: @row.name }
+        - @values.each do |v|
+          .form-group
+            = label_tag nil, "Value: #{v.value}", class: 'control-label'
+            = hidden_field_tag 'housing_attribute_name[value_renames][][old_value]', v.value
+            = text_field_tag 'housing_attribute_name[value_renames][][new_value]', v.value, class: 'form-control'
+        %p.text-muted
+          Renaming into a name or value that already exists as this same type (#{type_label})
+          merges the two. A same name used as the other type is a separate entity and is unaffected.
+      .form-actions.text-right
+        = f.button :submit, class: 'btn btn-primary'
+  .col-sm-6
+- if @values.any?
+  .values-table.mb-4
+    %h2 Available Options
+    %table.table.table-striped
+      %thead
+        %tr
+          %th Value
+          %th In Use
+      %tbody
+        - @values.each do |v|
+          %tr
+            %td= v.value
+            %td= v.count
+
+%h2 Currently Used By
+%table.table.table-striped
+  %thead
+    %tr
+      %th Type
+      %th Record
+      %th Value
+  %tbody
+    - @rows.each do |row|
+      %tr
+        %td= housingable_type(row.housingable)
+        %td= link_to housingable_name(row.housingable), housingable_edit_path(row.housingable)
+        %td= row.value

--- a/app/views/admin/housing_attribute_names/index.haml
+++ b/app/views/admin/housing_attribute_names/index.haml
@@ -1,0 +1,16 @@
+- title = "Housing Attributes"
+- content_for :title, title
+= render 'menus/admin_tabs'
+%h1= content_for :title
+%table.table.table-striped
+  %thead
+    %tr
+      %th Name
+      %th Type
+      %th In Use
+  %tbody
+    - @names.each do |n|
+      %tr
+        %td= link_to n.name, edit_admin_housing_attribute_name_path(n.id)
+        %td= n.type
+        %td= n.count

--- a/app/views/menus/_admin_tabs.haml
+++ b/app/views/menus/_admin_tabs.haml
@@ -18,6 +18,9 @@
   -if can_manage_config?
     %li.nav-item{role: "presentation", class: ('active' if current_page?(admin_match_routes_path))}
       = link_to 'Match Routes', admin_match_routes_path, class: 'nav-link'
+  -if can_manage_config?
+    %li.nav-item{role: "presentation", class: ('active' if current_page?(admin_housing_attribute_names_path))}
+      = link_to 'Housing Attributes', admin_housing_attribute_names_path, class: 'nav-link'
   - if can_manage_sessions?
     %li.nav-item{role: 'presentation', class: ('active' if controller_name == "sessions")}
       = link_to 'Sessions', admin_sessions_path, class: 'nav-link'

--- a/app/views/requirement_manager/_inherited_rules.html.haml
+++ b/app/views/requirement_manager/_inherited_rules.html.haml
@@ -1,5 +1,5 @@
 - unless local_assigns[:show_label] == false
-  %label Inherited Rules
+  %label Inherited Requirements
 - if inheritee.inherited_requirements_by_source.values.none?(&:present?)
   %p (none)
 - else

--- a/app/views/vacancy_submissions/_search_form.html.haml
+++ b/app/views/vacancy_submissions/_search_form.html.haml
@@ -1,6 +1,7 @@
 = form_tag(vacancy_submissions_path, method: :get) do
-  .input-group
+  .d-flex.flex-wrap.gap-2.align-items-center.mb-3
     - status_options = [['Queue (Awaiting + Changes Requested)', 'queue'], ['All Statuses', 'all']] + VacancySubmissionsHelper::STATUS_DISPLAY.map { |k, v| [v, k] }
-    = select_tag :status, options_for_select(status_options, params[:status].presence || 'queue'), class: 'form-select'
-    %input.form-control{name: :q, type: :text, placeholder: @prompt, value: @search_string}
-    %button.btn.btn-primary{type: :submit} Search
+    = select_tag :status, options_for_select(status_options, params[:status].presence || 'queue'), class: 'form-select', style: 'width: auto;'
+    = select_tag :program_id, options_for_select([['All Programs', '']] + @programs, params[:program_id]), class: 'select2', style: 'width: 260px;'
+    %button.btn.btn-primary{type: :submit} Update Filter
+= render 'init_select2'

--- a/app/views/vacancy_submissions/_vacancy.html.haml
+++ b/app/views/vacancy_submissions/_vacancy.html.haml
@@ -2,4 +2,5 @@
 - if is_voucher
   = render 'vacancy_submissions/vacancy_vouchers', unit_list: unit_list
 - else
-  = render 'vacancy_submissions/vacancy_units', unit_list: unit_list, default_building_id: sub_program&.building_id, confidential: sub_program&.confidential?
+  - confidential = sub_program&.confidential? || sub_program&.program&.confidential?
+  = render 'vacancy_submissions/vacancy_units', unit_list: unit_list, default_building_id: sub_program&.building_id, confidential: confidential

--- a/app/views/vacancy_submissions/index.html.haml
+++ b/app/views/vacancy_submissions/index.html.haml
@@ -6,8 +6,6 @@
         %span.icon-plus
         New Vacancy
 
-- @prompt = 'Search by program name...'
-
 .col-md-9
   = render 'search_form'
 

--- a/app/views/vacancy_submissions/show.html.haml
+++ b/app/views/vacancy_submissions/show.html.haml
@@ -96,7 +96,7 @@
     .c-card__header
       %h2 Inherited Requirements
     .c-card__content
-      = render 'requirement_manager/inherited_rules', inheritee: @sub_program
+      = render 'requirement_manager/inherited_rules', inheritee: @sub_program, show_label: false
 
 - if @submission.resubmittable? && can_add_vacancies?
   .c-card

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
     resources :match_routes, only: [:index, :edit, :update] do
       resources :weighting_rules, on: :member, except: [:create]
     end
+    resources :housing_attribute_names, only: [:index, :edit, :update]
     resources :sessions, only: [:index, :destroy]
   end
 

--- a/docs/features/requirements_manager.md
+++ b/docs/features/requirements_manager.md
@@ -136,7 +136,7 @@ The requirement manager is rendered via partial:
 - `form`: SimpleForm form builder
 - `selected_requirements_heading`: Label for the requirements section
 - `help_text`: Optional help text
-- `hide_inherited`: Hide inherited rules section
+- `hide_inherited`: Hide inherited requirements section
 - `on_unit`: Use alternate names for unit context
 - `section_header`: Override default "Rules" header
 - `note_context`: Context symbol for `selection_note` (e.g., `:voucher`)

--- a/spec/controllers/vacancy_submissions_controller_spec.rb
+++ b/spec/controllers/vacancy_submissions_controller_spec.rb
@@ -40,6 +40,30 @@ RSpec.describe VacancySubmissionsController, type: :controller do
       get :index
       expect(response).to have_http_status(:ok)
     end
+
+    context 'rendering the program filter' do
+      render_views
+
+      it 'renders a select2 dropdown of programs and an Update Filter button, not a text search box' do
+        create(:vacancy_submission, the_program: create(:program, name: 'Sunset Housing'))
+        get :index
+
+        expect(response.body).to include('select2')
+        expect(response.body).to include('Sunset Housing')
+        expect(response.body).to include('Update Filter')
+        expect(response.body).not_to include('name="q"')
+      end
+
+      it 'excludes programs that have no vacancy submissions' do
+        create(:vacancy_submission, the_program: create(:program, name: 'Sunset Housing'))
+        create(:program, name: 'Never Submitted')
+
+        get :index
+
+        expect(response.body).to include('Sunset Housing')
+        expect(response.body).not_to include('Never Submitted')
+      end
+    end
   end
 
   describe 'GET #new' do

--- a/spec/controllers/vacancy_submissions_controller_spec.rb
+++ b/spec/controllers/vacancy_submissions_controller_spec.rb
@@ -224,10 +224,17 @@ RSpec.describe VacancySubmissionsController, type: :controller do
       expect(response.body).to include('This program is confidential, do not enter a real address as the unit number')
     end
 
-    it 'omits the confidential warning when the sub-program is not confidential' do
+    it 'omits the confidential warning when neither the program nor the sub-program is confidential' do
       sub_program = create(:sub_program, program: program, program_type: 'Project-Based', building: building, confidential: false)
       get_vacancy_section(sub_program)
       expect(response.body).not_to include('This program is confidential')
+    end
+
+    it 'shows the confidential warning when the program is confidential, even if the sub-program is not' do
+      confidential_program = create(:program, confidential: true)
+      sub_program = create(:sub_program, program: confidential_program, program_type: 'Project-Based', building: building, confidential: false)
+      get_vacancy_section(sub_program)
+      expect(response.body).to include('This program is confidential, do not enter a real address as the unit number')
     end
   end
 

--- a/spec/models/housing_attribute_spec.rb
+++ b/spec/models/housing_attribute_spec.rb
@@ -133,13 +133,19 @@ RSpec.describe HousingAttribute, type: :model do
       expect(untouched_type.reload.name).to eq('Elevater')
     end
 
-    it 'does nothing when the new name is blank or unchanged' do
+    it 'does nothing when the new name is blank' do
       row = create(:housing_attribute, :without_value, housingable: building, name: 'Elevator')
 
       expect { described_class.rename(old_name: 'Elevator', new_name: '', include_value: false) }.
         not_to(change { row.reload.name })
-      expect { described_class.rename(old_name: 'Elevator', new_name: 'Elevator', include_value: false) }.
-        not_to(change { row.reload.versions.count })
+    end
+
+    it 'skips the update entirely when the new name equals the old name' do
+      create(:housing_attribute, :without_value, housingable: building, name: 'Elevator')
+
+      expect(described_class).not_to receive(:transaction)
+
+      described_class.rename(old_name: 'Elevator', new_name: 'Elevator', include_value: false)
     end
   end
 
@@ -158,11 +164,12 @@ RSpec.describe HousingAttribute, type: :model do
       expect(other_name.reload.value).to eq('1')
     end
 
-    it 'does nothing when the old and new value are the same' do
-      row = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+    it 'skips the update entirely when the old and new value are the same' do
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
 
-      expect { described_class.rename_value(name: 'Bedrooms', old_value: '1', new_value: '1') }.
-        not_to(change { row.reload.versions.count })
+      expect(described_class).not_to receive(:transaction)
+
+      described_class.rename_value(name: 'Bedrooms', old_value: '1', new_value: '1')
     end
   end
 end

--- a/spec/models/housing_attribute_spec.rb
+++ b/spec/models/housing_attribute_spec.rb
@@ -65,4 +65,104 @@ RSpec.describe HousingAttribute, type: :model do
       expect(described_class.existing_amenities).not_to include('Furniture')
     end
   end
+
+  describe '.name_summary' do
+    it 'reports a separate entry per name+type combination, never Mixed, and excludes soft-deleted rows' do
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '2')
+      create(:housing_attribute, :without_value, housingable: building, name: 'Elevator')
+      create(:housing_attribute, :with_value, housingable: building, name: 'Parking', value: 'Included')
+      create(:housing_attribute, housingable: building, name: 'Parking', include_value: false, value: nil)
+      deleted = create(:housing_attribute, :without_value, housingable: building, name: 'Removed')
+      deleted.destroy
+
+      summary = described_class.name_summary
+
+      expect(summary.map { |n| [n.name, n.type] }).to contain_exactly(
+        ['Bedrooms', 'Attribute'],
+        ['Elevator', 'Amenity'],
+        ['Parking', 'Attribute'],
+        ['Parking', 'Amenity'],
+      )
+      bedrooms = summary.find { |n| n.name == 'Bedrooms' }
+      parking_attribute = summary.find { |n| n.name == 'Parking' && n.type == 'Attribute' }
+      parking_amenity = summary.find { |n| n.name == 'Parking' && n.type == 'Amenity' }
+      expect(bedrooms.count).to eq(2)
+      expect(parking_attribute.count).to eq(1)
+      expect(parking_amenity.count).to eq(1)
+    end
+  end
+
+  describe '.value_summary' do
+    it 'counts each distinct value for the given name and ignores other names' do
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '2')
+      create(:housing_attribute, :with_value, housingable: building, name: 'Bathrooms', value: '1')
+
+      summary = described_class.value_summary('Bedrooms').index_by(&:value)
+
+      expect(summary.keys).to contain_exactly('1', '2')
+      expect(summary['1'].count).to eq(2)
+      expect(summary['2'].count).to eq(1)
+    end
+  end
+
+  describe '.rename' do
+    around do |example|
+      # PaperTrail is disabled globally for performance; enable it for this spec.
+      PaperTrail.enabled = true
+      example.run
+      PaperTrail.enabled = false
+    end
+
+    it 'renames every matching row of the same value-type across housingable types, leaves the other value-type and other names untouched, and records a paper trail version per row' do
+      unit = create(:unit, building: building)
+      building_row = create(:housing_attribute, :without_value, housingable: building, name: 'Elevater')
+      unit_row = create(:housing_attribute, :without_value, housingable: unit, name: 'Elevater')
+      untouched_name = create(:housing_attribute, :without_value, housingable: building, name: 'Dishwasher')
+      untouched_type = create(:housing_attribute, :with_value, housingable: building, name: 'Elevater', value: 'Working')
+
+      expect { described_class.rename(old_name: 'Elevater', new_name: 'Elevator', include_value: false) }.
+        to change { building_row.reload.versions.count }.by(1).
+        and change { unit_row.reload.versions.count }.by(1)
+
+      expect(building_row.reload.name).to eq('Elevator')
+      expect(unit_row.reload.name).to eq('Elevator')
+      expect(untouched_name.reload.name).to eq('Dishwasher')
+      expect(untouched_type.reload.name).to eq('Elevater')
+    end
+
+    it 'does nothing when the new name is blank or unchanged' do
+      row = create(:housing_attribute, :without_value, housingable: building, name: 'Elevator')
+
+      expect { described_class.rename(old_name: 'Elevator', new_name: '', include_value: false) }.
+        not_to(change { row.reload.name })
+      expect { described_class.rename(old_name: 'Elevator', new_name: 'Elevator', include_value: false) }.
+        not_to(change { row.reload.versions.count })
+    end
+  end
+
+  describe '.rename_value' do
+    it 'renames only rows matching both the name and the old value' do
+      matching_one = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      matching_two = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      other_value = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '2')
+      other_name = create(:housing_attribute, :with_value, housingable: building, name: 'Bathrooms', value: '1')
+
+      described_class.rename_value(name: 'Bedrooms', old_value: '1', new_value: 'One')
+
+      expect(matching_one.reload.value).to eq('One')
+      expect(matching_two.reload.value).to eq('One')
+      expect(other_value.reload.value).to eq('2')
+      expect(other_name.reload.value).to eq('1')
+    end
+
+    it 'does nothing when the old and new value are the same' do
+      row = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+
+      expect { described_class.rename_value(name: 'Bedrooms', old_value: '1', new_value: '1') }.
+        not_to(change { row.reload.versions.count })
+    end
+  end
 end

--- a/spec/models/vacancy_submission_spec.rb
+++ b/spec/models/vacancy_submission_spec.rb
@@ -338,19 +338,46 @@ RSpec.describe VacancySubmission, type: :model do
     let!(:active) { create(:vacancy_submission, status: 'active') }
 
     it 'returns queue records by default' do
-      result = described_class.filtered(search: nil, status_filter: 'queue')
+      result = described_class.filtered(program_id: nil, status_filter: 'queue')
       expect(result).to include(awaiting, changes)
       expect(result).not_to include(active)
     end
 
     it 'returns all records for all filter' do
-      result = described_class.filtered(search: nil, status_filter: 'all')
+      result = described_class.filtered(program_id: nil, status_filter: 'all')
       expect(result).to include(awaiting, changes, active)
     end
 
     it 'returns only the specified status' do
-      result = described_class.filtered(search: nil, status_filter: 'active')
+      result = described_class.filtered(program_id: nil, status_filter: 'active')
       expect(result).to contain_exactly(active)
+    end
+
+    it 'returns only submissions for the given program' do
+      target_program = create(:program)
+      matching = create(:vacancy_submission, status: 'active', the_program: target_program)
+      other_program_submission = create(:vacancy_submission, status: 'active')
+
+      result = described_class.filtered(program_id: target_program.id, status_filter: 'all')
+
+      expect(result).to include(matching)
+      expect(result).not_to include(other_program_submission, awaiting, changes, active)
+    end
+  end
+
+  describe '.program_ids_in_use' do
+    it 'returns each distinct program id used by any submission regardless of status, and excludes unused programs' do
+      active_program = create(:program)
+      queue_program = create(:program)
+      unused_program = create(:program)
+      create(:vacancy_submission, status: 'active', the_program: active_program)
+      create(:vacancy_submission, status: 'active', the_program: active_program)
+      create(:vacancy_submission, status: 'awaiting_approval', the_program: queue_program)
+
+      result = described_class.program_ids_in_use
+
+      expect(result).to contain_exactly(active_program.id, queue_program.id)
+      expect(result).not_to include(unused_program.id)
     end
   end
 

--- a/spec/requests/admin/housing_attribute_names_spec.rb
+++ b/spec/requests/admin/housing_attribute_names_spec.rb
@@ -1,0 +1,137 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin::HousingAttributeNames', type: :request do
+  describe 'GET index' do
+    it 'redirects to root without can_manage_config' do
+      role = create(:role, can_manage_config: false)
+      user = create(:user)
+      user.roles << role
+      sign_in user
+
+      get admin_housing_attribute_names_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    context 'as a user with can_manage_config' do
+      let!(:admin_role) { create(:role, can_manage_config: true) }
+      let!(:admin) { create(:user) }
+      let!(:building) { create(:building) }
+      let!(:attribute) { create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1') }
+
+      before do
+        admin.roles << admin_role
+        sign_in admin
+      end
+
+      it 'links each listed name to its edit page' do
+        get admin_housing_attribute_names_path
+
+        expect(response.body).to include('Bedrooms')
+        expect(response.body).to include(edit_admin_housing_attribute_name_path(attribute.id))
+      end
+    end
+  end
+
+  describe 'GET edit' do
+    let!(:admin_role) { create(:role, can_manage_config: true) }
+    let!(:admin) { create(:user) }
+
+    before do
+      admin.roles << admin_role
+      sign_in admin
+    end
+
+    it 'shows every building and unit currently using the name and type, with their values, and excludes other names and the other type of the same name' do
+      building = create(:building, name: 'Sunset Building')
+      unit = create(:unit, name: 'Unit 2B', building: create(:building, name: 'Ocean View'))
+      attribute = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+      create(:housing_attribute, :with_value, housingable: unit, name: 'Bedrooms', value: '2')
+      other_building = create(:building, name: 'Not Related')
+      create(:housing_attribute, :without_value, housingable: other_building, name: 'Elevator')
+      amenity_building = create(:building, name: 'Amenity Building')
+      create(:housing_attribute, housingable: amenity_building, name: 'Bedrooms', include_value: false, value: nil)
+
+      get edit_admin_housing_attribute_name_path(attribute.id)
+
+      expect(response.body).to include('Sunset Building')
+      expect(response.body).to include('Unit 2B')
+      expect(response.body).to include(edit_building_path(building))
+      expect(response.body).to include(edit_unit_path(unit))
+      expect(response.body).not_to include('Not Related')
+      expect(response.body).not_to include('Amenity Building')
+    end
+  end
+
+  describe 'PATCH update' do
+    it 'does not rename when the user lacks can_manage_config' do
+      role = create(:role, can_manage_config: false)
+      user = create(:user)
+      user.roles << role
+      sign_in user
+      attribute = create(:housing_attribute, :without_value, housingable: create(:building), name: 'Elevator')
+
+      patch admin_housing_attribute_name_path(attribute.id), params: { housing_attribute_name: { name: 'Hacked' } }
+
+      expect(response).to redirect_to(root_path)
+      expect(attribute.reload.name).to eq('Elevator')
+    end
+
+    context 'as a user with can_manage_config' do
+      let!(:admin_role) { create(:role, can_manage_config: true) }
+      let!(:admin) { create(:user) }
+
+      before do
+        admin.roles << admin_role
+        sign_in admin
+      end
+
+      it 'renames the attribute and merges into an already-existing name of the same value-type' do
+        building = create(:building)
+        typo = create(:housing_attribute, :without_value, housingable: building, name: 'Elevater')
+        create(:housing_attribute, :without_value, housingable: create(:unit, building: building), name: 'Elevator')
+
+        patch admin_housing_attribute_name_path(typo.id), params: { housing_attribute_name: { name: 'Elevator' } }
+
+        expect(response).to redirect_to(edit_admin_housing_attribute_name_path(typo.id))
+        expect(typo.reload.name).to eq('Elevator')
+        expect(HousingAttribute.where(name: 'Elevator', include_value: false).count).to eq(2)
+      end
+
+      it 'renaming an attribute-type name does not affect an amenity-type row with the same name, and vice versa' do
+        building = create(:building)
+        attribute_row = create(:housing_attribute, :with_value, housingable: building, name: 'Elevator', value: 'Freight')
+        amenity_row = create(:housing_attribute, :without_value, housingable: building, name: 'Elevator')
+
+        patch admin_housing_attribute_name_path(attribute_row.id), params: { housing_attribute_name: { name: 'Freight Elevator' } }
+
+        expect(attribute_row.reload.name).to eq('Freight Elevator')
+        expect(amenity_row.reload.name).to eq('Elevator')
+
+        patch admin_housing_attribute_name_path(amenity_row.id), params: { housing_attribute_name: { name: 'Elevator Access' } }
+
+        expect(amenity_row.reload.name).to eq('Elevator Access')
+        expect(attribute_row.reload.name).to eq('Freight Elevator')
+      end
+
+      it 'renames a value via value_renames without changing the name' do
+        building = create(:building)
+        attribute = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+
+        patch admin_housing_attribute_name_path(attribute.id),
+              params: { housing_attribute_name: { value_renames: [{ old_value: '1', new_value: 'One' }] } }
+
+        expect(attribute.reload.name).to eq('Bedrooms')
+        expect(attribute.reload.value).to eq('One')
+      end
+    end
+  end
+end

--- a/spec/requests/admin/housing_attribute_names_spec.rb
+++ b/spec/requests/admin/housing_attribute_names_spec.rb
@@ -42,32 +42,46 @@ RSpec.describe 'Admin::HousingAttributeNames', type: :request do
   end
 
   describe 'GET edit' do
-    let!(:admin_role) { create(:role, can_manage_config: true) }
-    let!(:admin) { create(:user) }
-
-    before do
-      admin.roles << admin_role
-      sign_in admin
-    end
-
-    it 'shows every building and unit currently using the name and type, with their values, and excludes other names and the other type of the same name' do
-      building = create(:building, name: 'Sunset Building')
-      unit = create(:unit, name: 'Unit 2B', building: create(:building, name: 'Ocean View'))
-      attribute = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
-      create(:housing_attribute, :with_value, housingable: unit, name: 'Bedrooms', value: '2')
-      other_building = create(:building, name: 'Not Related')
-      create(:housing_attribute, :without_value, housingable: other_building, name: 'Elevator')
-      amenity_building = create(:building, name: 'Amenity Building')
-      create(:housing_attribute, housingable: amenity_building, name: 'Bedrooms', include_value: false, value: nil)
+    it 'redirects to root without can_manage_config' do
+      role = create(:role, can_manage_config: false)
+      user = create(:user)
+      user.roles << role
+      sign_in user
+      attribute = create(:housing_attribute, :without_value, housingable: create(:building), name: 'Elevator')
 
       get edit_admin_housing_attribute_name_path(attribute.id)
 
-      expect(response.body).to include('Sunset Building')
-      expect(response.body).to include('Unit 2B')
-      expect(response.body).to include(edit_building_path(building))
-      expect(response.body).to include(edit_unit_path(unit))
-      expect(response.body).not_to include('Not Related')
-      expect(response.body).not_to include('Amenity Building')
+      expect(response).to redirect_to(root_path)
+    end
+
+    context 'as a user with can_manage_config' do
+      let!(:admin_role) { create(:role, can_manage_config: true) }
+      let!(:admin) { create(:user) }
+
+      before do
+        admin.roles << admin_role
+        sign_in admin
+      end
+
+      it 'shows every building and unit currently using the name and type, with their values, and excludes other names and the other type of the same name' do
+        building = create(:building, name: 'Sunset Building')
+        unit = create(:unit, name: 'Unit 2B', building: create(:building, name: 'Ocean View'))
+        attribute = create(:housing_attribute, :with_value, housingable: building, name: 'Bedrooms', value: '1')
+        create(:housing_attribute, :with_value, housingable: unit, name: 'Bedrooms', value: '2')
+        other_building = create(:building, name: 'Not Related')
+        create(:housing_attribute, :without_value, housingable: other_building, name: 'Elevator')
+        amenity_building = create(:building, name: 'Amenity Building')
+        create(:housing_attribute, housingable: amenity_building, name: 'Bedrooms', include_value: false, value: nil)
+
+        get edit_admin_housing_attribute_name_path(attribute.id)
+
+        expect(response.body).to include('Sunset Building')
+        expect(response.body).to include('Unit 2B')
+        expect(response.body).to include(edit_building_path(building))
+        expect(response.body).to include(edit_unit_path(unit))
+        expect(response.body).not_to include('Not Related')
+        expect(response.body).not_to include('Amenity Building')
+      end
     end
   end
 
@@ -131,6 +145,17 @@ RSpec.describe 'Admin::HousingAttributeNames', type: :request do
 
         expect(attribute.reload.name).to eq('Bedrooms')
         expect(attribute.reload.value).to eq('One')
+      end
+
+      it 'applies value_renames against the new name when the name is changed in the same request' do
+        building = create(:building)
+        typo = create(:housing_attribute, :with_value, housingable: building, name: 'Bedroms', value: '1')
+
+        patch admin_housing_attribute_name_path(typo.id),
+              params: { housing_attribute_name: { name: 'Bedrooms', value_renames: [{ old_value: '1', new_value: 'One' }] } }
+
+        expect(typo.reload.name).to eq('Bedrooms')
+        expect(typo.reload.value).to eq('One')
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch


## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

* Adjusts the filter/search on vacancy submissions to use program type-ahead and filter language over "search"
* Adds global admin list, edit, update pages for Housing Attributes and Amenities
* Globally updates `Inherited Rules` -> `Inherited Requirements` 
* Hides the duplicate label of `Inherited Requirements` on the vacancy submission show page
* Includes confidential programs, not just sub-programs when determining if it should show the confidentiality warning.

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
