### PR TITLE
fix: 9487 don't de-list de-identified clients on parse-error

### DIFF
--- a/app/models/deidentified_clients_xlsx.rb
+++ b/app/models/deidentified_clients_xlsx.rb
@@ -48,9 +48,14 @@ class DeidentifiedClientsXlsx < ApplicationRecord
     # transaction commits
     sentry_queue = []
 
-    # Availability is reset up front, so the whole roster must be atomic: a non-recoverable
-    # otherwise a failure could leave all clients in the agency unavailable.
+    unapplied_client_ids = []
+
+    # Availability is reset up front, so a raise anywhere in the loop must roll the whole roster
+    # back rather than leave every client in the agency unavailable.
     DeidentifiedClient.transaction do
+      # Must be plucked before the update_all below marks every client in the agency unavailable.
+      previously_available_ids = @update_availability ? DeidentifiedClient.where(agency: agency, available: true).pluck(:id) : []
+
       DeidentifiedClient.where(agency: agency).update_all(available: false) if @update_availability
 
       @xlsx.each_with_index do |raw, index|
@@ -80,6 +85,7 @@ class DeidentifiedClientsXlsx < ApplicationRecord
             sentry_queue << e
             client.errors.add(:base, "Could not process row: #{e.message}")
           end
+          unapplied_client_ids << client.id if client.persisted?
           next
         end
 
@@ -97,6 +103,7 @@ class DeidentifiedClientsXlsx < ApplicationRecord
           # A false return with no validation errors means a callback halted the save due to
           # an internal error, not bad user data
           sentry_queue << "De-identified roster save halted for client #{client.client_identifier}" if client.errors.empty?
+          unapplied_client_ids << client.id if client.persisted?
           next
         end
 
@@ -113,6 +120,12 @@ class DeidentifiedClientsXlsx < ApplicationRecord
         # is a DB-level, non-user-correctable error. Raise loudly and roll back the tx
         assessment.save!(validate: false)
       end
+
+      # A row that bailed out must be a no-op, so give its client back the availability the reset
+      # took away — only for clients already available, since a row we couldn't read is no reason
+      # to activate anyone.
+      restorable_ids = unapplied_client_ids & previously_available_ids
+      DeidentifiedClient.where(id: restorable_ids).update_all(available: true) if restorable_ids.any?
     end
 
     # Transaction committed, report the internal errors

--- a/app/views/deidentified_clients/choose_upload.haml
+++ b/app/views/deidentified_clients/choose_upload.haml
@@ -15,6 +15,6 @@
       .form-inputs
         = f.input :file, as: :file, label: false, required: true
         = f.input :agency_id, as: :select_2, collection: @upload.agency_options_for_select(current_user), include_blank: 'Select an agency', required: true
-        = f.input :update_availability, as: :radio_buttons, collection: [['Yes', true], ['No', false]], label: 'Update client availability', hint: 'Make only the clients in the selected agency that appear in the selected file available', required: true
+        = f.input :update_availability, as: :radio_buttons, collection: [['Yes', true], ['No', false]], label: 'Update client availability', hint: 'Clients in the selected agency that appear in the selected file become available; those absent from it become unavailable. A row that can\'t be read is skipped, leaving that client\'s current availability unchanged.', required: true
       .form-actions
         = f.button :submit, value: 'Upload Excel'

--- a/app/views/deidentified_clients/import.haml
+++ b/app/views/deidentified_clients/import.haml
@@ -16,6 +16,9 @@
         %li= identifier
 
 - if problems > 0
+  %p.text-muted
+    The rows below were skipped, so nothing changed for these clients, including their
+    availability. Correct the values and upload again.
   .row
   .col-sm-12
     .table-responsive

--- a/spec/models/deidentified_clients_xlsx_spec.rb
+++ b/spec/models/deidentified_clients_xlsx_spec.rb
@@ -151,6 +151,113 @@ RSpec.describe DeidentifiedClientsXlsx, type: :model do
     expect(DeidentifiedClient.find_by(agency: agency_a, client_identifier: home_base_id)&.available).to eq(true)
   end
 
+  it 'keeps a client in the roster available even when their row fails to parse' do
+    existing = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'HB-BADCELL',
+      available: true,
+      actively_homeless: true,
+      veteran: false,
+    )
+    bad_row = ['1', 'No', 'HB-BADCELL', 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'MAYBE', 'No', 'No']
+
+    importer = DeidentifiedClientsXlsx.new(content: build_xlsx([row, bad_row]))
+    importer.import(agency_a, update_availability: true)
+
+    expect(existing.reload.available).to eq(true)
+    # The row is a full no-op, not just availability-preserving: the unparseable Veteran cell
+    # must not have been applied.
+    expect(existing.veteran).to eq(false)
+    failed = importer.clients.detect { |c| c.client_identifier == 'HB-BADCELL' }
+    expect(failed.errors).to be_present
+    expect(importer.touched).to eq(0)
+  end
+
+  it 'keeps a client available when their row is valid but the save fails' do
+    existing = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: home_base_id,
+      available: true,
+      actively_homeless: true,
+    )
+    # The row must parse completely clean for this to exercise the no-validation-errors branch:
+    # an unknown shelter location attaches an error without raising, which would look like bad
+    # user data instead.
+    Neighborhood.create!(name: 'Fort Worth')
+    allow_any_instance_of(DeidentifiedClient).to receive(:update).and_return(false)
+
+    # A false return with no validation errors is an internal failure, not bad user data, so it
+    # must be reported rather than silently skipped.
+    expect(Sentry).to receive(:capture_message).with("De-identified roster save halted for client #{home_base_id}")
+
+    DeidentifiedClientsXlsx.new(content: content).import(agency_a, update_availability: true)
+
+    expect(existing.reload.available).to eq(true)
+  end
+
+  it 'does not activate a previously unavailable client when their row fails to parse' do
+    # Activating a client off a row we couldn't parse would return them to matching with the stale
+    # attributes already on record.
+    existing = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'HB-BADCELL',
+      available: false,
+      actively_homeless: true,
+    )
+    bad_row = ['1', 'No', 'HB-BADCELL', 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'MAYBE', 'No', 'No']
+
+    DeidentifiedClientsXlsx.new(content: build_xlsx([row, bad_row])).import(agency_a, update_availability: true)
+
+    expect(existing.reload.available).to eq(false)
+  end
+
+  it 'still de-lists a client absent from the roster when another row fails to parse' do
+    dropped = create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'NOT-IN-FILE',
+      available: true,
+      actively_homeless: true,
+    )
+    create(
+      :deidentified_client,
+      agency: agency_a,
+      client_identifier: 'HB-BADCELL',
+      available: true,
+      actively_homeless: true,
+    )
+    bad_row = ['1', 'No', 'HB-BADCELL', 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'MAYBE', 'No', 'No']
+
+    DeidentifiedClientsXlsx.new(content: build_xlsx([row, bad_row])).import(agency_a, update_availability: true)
+
+    expect(dropped.reload.available).to eq(false)
+  end
+
+  it 'lets the parseable row win when a client appears on both a good and a bad row' do
+    # A hand-maintained roster can list the same Home-base ID twice. The successful row must be
+    # applied regardless of which side of it the failing row falls on, and the end-of-loop
+    # availability restore must not undo it.
+    dup_a = create(:deidentified_client, agency: agency_a, client_identifier: 'HB-DUP-A', available: false, veteran: true)
+    dup_b = create(:deidentified_client, agency: agency_a, client_identifier: 'HB-DUP-B', available: false, veteran: true)
+    good = ->(id) { ['1', 'No', id, 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'No', 'No', 'No'] }
+    bad = ->(id) { ['1', 'No', id, 'No', 'No', '3', '240', 'Yes', 'No', 'No', 'Yes', 'No', 'MAYBE', 'No', 'No'] }
+
+    importer = DeidentifiedClientsXlsx.new(
+      content: build_xlsx([good.call('HB-DUP-A'), bad.call('HB-DUP-A'), bad.call('HB-DUP-B'), good.call('HB-DUP-B')]),
+    )
+    importer.import(agency_a, update_availability: true)
+
+    # good-then-bad
+    expect(dup_a.reload.available).to eq(true)
+    expect(dup_a.veteran).to eq(false)
+    # bad-then-good
+    expect(dup_b.reload.available).to eq(true)
+    expect(dup_b.veteran).to eq(false)
+  end
+
   it 'leaves existing availability untouched when update_availability is not set' do
     # A client already available but absent from the uploaded roster. With update_availability
     # off there is no up-front reset, so this client must stay available rather than be de-listed.


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch

## Description
The up-front availability reset was never undone for skipped rows, so one bad cell silently made a client who was in the file ineligible for matching. Failed rows now restore their prior availability, making them a true no-op.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [x] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
