### PR TITLE
Add release tag badge to header and system status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -190,4 +190,5 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-mocks'
   gem 'shoulda-matchers'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,9 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.7)
     csv (3.3.5)
     daemons (1.4.1)
@@ -695,6 +698,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
@@ -861,6 +868,7 @@ DEPENDENCIES
   virtus
   warning
   web-console
+  webmock
   whenever
   with_advisory_lock
   xlsxtream
@@ -950,6 +958,7 @@ CHECKSUMS
   coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   daemons (1.4.1) sha256=8fc76d76faec669feb5e455d72f35bd4c46dc6735e28c420afb822fac1fa9a1d
@@ -1133,6 +1142,7 @@ CHECKSUMS
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   warning (1.5.0) sha256=0f12c49fea0c06757778eefdcc7771e4fd99308901e3d55c504d87afdd718c53
   web-console (4.2.1) sha256=e7bcf37a10ea2b4ec4281649d1cee461b32232d0a447e82c786e6841fd22fe20
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
   websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   whenever (1.1.2) sha256=af139a25cf6b5c7d2122686724c0b9a4a7495135a1f79a404e29f4cce48abd83

--- a/app/controllers/system_status_controller.rb
+++ b/app/controllers/system_status_controller.rb
@@ -87,6 +87,7 @@ class SystemStatusController < ApplicationController
       jobs_message: jobs_message,
       revision: Git.revision,
       branch: Git.branch,
+      release: Git.release,
       hostname: `hostname`.chomp,
       cache: cache_message,
       user_count_positive: User.all.any?,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -188,7 +188,7 @@ module ApplicationHelper
     return nil unless release
 
     content_tag :div, class: 'navbar-text' do
-      content_tag :span, release, class: 'badge badge-secondary p-2'
+      content_tag :span, release, class: 'badge badge-warning p-2'
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -183,6 +183,15 @@ module ApplicationHelper
     Git.revision
   end
 
+  def release_info
+    release = Git.release
+    return nil unless release
+
+    content_tag :div, class: 'navbar-text' do
+      content_tag :span, release, class: 'badge badge-secondary p-2'
+    end
+  end
+
   def help_link
     @help_link ||= begin
       return nil unless help_for_path

--- a/app/views/layouts/_header_warnings.haml
+++ b/app/views/layouts/_header_warnings.haml
@@ -22,6 +22,9 @@
               (EKS)
       .git-branch.ml-4
         = branch_info
+      - if release_info
+        .git-branch.ml-4
+          = release_info
       .git-revision.ml-4
         .navbar-text
           .badge.badge-danger.p-2

--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -36,6 +36,17 @@ echo 'Setting Timezone'
 cp /usr/share/zoneinfo/$TIMEZONE /app/etc-localtime
 echo $TIMEZONE >/etc/timezone
 
+# Target web containers for release tag resolution.
+case "$CONTAINER_VARIANT" in
+  '' | web)
+    echo 'Resolving release tag from the deployed commit'
+    bundle exec ruby ./lib/util/git/release_resolver.rb || echo 'release resolution failed; continuing'
+    ;;
+  *)
+    echo "Skipping release tag resolution on $CONTAINER_VARIANT container"
+    ;;
+esac
+
 if [[ "$CONTAINER_VARIANT" == "dj" ]]; then
   if [[ "${ENABLE_DJ_METRICS}" = "true" ]]; then
     echo "Starting metrics server"

--- a/lib/util/git.rb
+++ b/lib/util/git.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
+require_relative 'git/release_resolver'
+
 class Git
   def self.revision
     if Rails.env.development?
@@ -24,4 +26,48 @@ class Git
   rescue StandardError
     'unknown'
   end
+
+  # Release this container is running, e.g. "v1.2.3", or "v1.2.3+4" when 4
+  # commits past that tag. nil when unknown.
+  def self.release
+    details = release_details
+    return nil if details.nil?
+
+    tag = details[:tag]
+    return nil if tag.blank?
+
+    return tag if details[:ahead].to_i.zero?
+
+    "#{tag}+#{details[:ahead].to_i}"
+  end
+
+  # Reads the cache file Git::ReleaseResolver writes at container start. Returns
+  # { tag:, ahead: }, or nil when the file is absent, unreadable, or was computed for a
+  # different commit. Memoizes nil as well as a found value.
+  def self.release_details
+    return nil if Rails.env.development?
+    return @release_details if defined?(@release_details)
+
+    @release_details = resolved_release_details
+  end
+
+  # Test support only.
+  def self.reset_memo!
+    remove_instance_variable(:@release_details) if defined?(@release_details)
+  end
+
+  def self.resolved_release_details
+    path = ReleaseResolver::CACHE_PATH
+    return nil unless File.exist?(path)
+
+    details = JSON.parse(File.read(path), symbolize_names: true)
+    # Ignore a cache file computed for a different commit.
+    return nil unless details[:revision].to_s == revision.to_s
+    return nil if details[:tag].to_s.empty?
+
+    details
+  rescue StandardError
+    nil
+  end
+  private_class_method :resolved_release_details
 end

--- a/lib/util/git.rb
+++ b/lib/util/git.rb
@@ -4,6 +4,8 @@
 # License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
+# frozen_string_literal: true
+
 require_relative 'git/release_resolver'
 
 class Git

--- a/lib/util/git/release_resolver.rb
+++ b/lib/util/git/release_resolver.rb
@@ -25,7 +25,7 @@ class Git
 
     class << self
       # @return [Hash, nil] { tag:, ahead:, revision: }
-      def resolve(revision)
+      def resolve(revision:)
         return nil if revision.nil? || revision.strip.empty? || revision.strip == 'unknown'
 
         revision = revision.strip
@@ -51,7 +51,7 @@ class Git
 
       # @return [Boolean] true when a cache file was written
       def write_cache_file(revision:, path: CACHE_PATH)
-        details = resolve(revision)
+        details = resolve(revision: revision)
         return false if details.nil?
 
         File.write(path, JSON.generate(details))

--- a/lib/util/git/release_resolver.rb
+++ b/lib/util/git/release_resolver.rb
@@ -1,0 +1,140 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Finds the release tag nearest to the deployed commit and writes it to
+# tmp/git_release.json for Git.release to read.
+#
+# Runs from docker/app/entrypoint.sh before the app boots, so it uses no Rails APIs.
+class Git
+  class ReleaseResolver
+    REPO = ENV.fetch('GITHUB_REPO', 'greenriver/boston-cas').freeze
+    CACHE_PATH = '/app/tmp/git_release.json'
+
+    # How many of the deployed commit's ancestors to search for a tag.
+    # Note: Github's maximum page size is 100, so this is the maximum number of commits to search.
+    LOOKBACK = 50
+
+    class << self
+      # @return [Hash, nil] { tag:, ahead:, revision: }
+      def resolve(revision)
+        return nil if revision.nil? || revision.strip.empty? || revision.strip == 'unknown'
+
+        revision = revision.strip
+        ancestors = ancestor_shas(revision)
+        return nil if ancestors.empty?
+
+        # a sha's index in `ancestors` is how many commits the revision is ahead of it
+        positions = {}
+        ancestors.each_with_index { |sha, index| positions[sha] ||= index }
+
+        nearest = nil
+        tags.each do |tag|
+          index = positions[tag[:sha]]
+          next if index.nil?
+          next if nearest && nearest[:ahead] <= index
+
+          nearest = { tag: tag[:name], ahead: index, revision: revision }
+        end
+        nearest
+      rescue StandardError
+        nil
+      end
+
+      # @return [Boolean] true when a cache file was written
+      def write_cache_file(revision:, path: CACHE_PATH)
+        details = resolve(revision)
+        return false if details.nil?
+
+        File.write(path, JSON.generate(details))
+        true
+      rescue StandardError
+        false
+      end
+
+      # Called by docker/app/entrypoint.sh. Never raises.
+      def run_from_entrypoint
+        revision = read_stamp('REVISION')
+        if revision.nil?
+          warn 'resolve_release: no REVISION file, skipping'
+          return
+        end
+
+        if write_cache_file(revision: revision)
+          details = JSON.parse(File.read(CACHE_PATH))
+          puts "resolve_release: #{details['tag']} (+#{details['ahead']})"
+        else
+          warn "resolve_release: no release tag within #{LOOKBACK} commits of the deployed " \
+               'revision; no release badge will be shown'
+        end
+      rescue StandardError => e
+        warn "resolve_release: #{e.class}: #{e.message}; no release badge will be shown"
+      end
+
+      private
+
+      # Reads a build stamp from the app root.
+      def read_stamp(name)
+        path = "/app/#{name}"
+        return nil unless File.exist?(path)
+
+        value = File.read(path).chomp
+        value.empty? ? nil : value
+      end
+
+      # The deployed commit and its ancestors, newest first.
+      def ancestor_shas(revision)
+        body = get(format('/repos/%s/commits', REPO), sha: revision, per_page: LOOKBACK, page: 1)
+        return [] if body.nil?
+
+        body.map { |commit| commit['sha'] }.compact
+      end
+
+      # Repo tags as { name:, sha: }, from up to two pages of 100. /tags is not ordered by
+      # date, so every page is read.
+      def tags
+        list = []
+        (1..2).each do |page|
+          body = get(format('/repos/%s/tags', REPO), per_page: 100, page: page)
+          break if body.nil?
+
+          body.each do |tag|
+            sha = tag.dig('commit', 'sha')
+            list << { name: tag['name'], sha: sha } if sha
+          end
+          break if body.length < 100
+        end
+        list
+      end
+
+      # @return [Array, nil] the parsed response body, or nil if the request failed or the
+      #   body was not an Array.
+      def get(path, params)
+        uri = URI::HTTPS.build(host: 'api.github.com', path: path, query: URI.encode_www_form(params))
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 5) do |http|
+          request = Net::HTTP::Get.new(uri)
+          request['Accept'] = 'application/vnd.github+json'
+          request['User-Agent'] = 'boston-cas-release-resolver'
+          http.request(request)
+        end
+        return nil unless response.is_a?(Net::HTTPSuccess)
+
+        body = JSON.parse(response.body)
+        body.is_a?(Array) ? body : nil
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end
+
+# Runs only when this file is executed directly, not when required or autoloaded.
+Git::ReleaseResolver.run_from_entrypoint if $PROGRAM_NAME == __FILE__

--- a/spec/controllers/system_status_controller_spec.rb
+++ b/spec/controllers/system_status_controller_spec.rb
@@ -1,0 +1,32 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SystemStatusController, type: :controller do
+  describe '#details' do
+    it 'includes the release alongside revision/branch in the JSON payload' do
+      allow(Git).to receive(:release).and_return('v1.2.3+4')
+
+      get :details
+
+      payload = JSON.parse(response.body)
+      expect(payload['release']).to eq('v1.2.3+4')
+    end
+
+    it 'omits/nils the release rather than erroring when none is available' do
+      allow(Git).to receive(:release).and_return(nil)
+
+      get :details
+
+      payload = JSON.parse(response.body)
+      expect(payload['release']).to be_nil
+      expect(response.status).not_to eq(500)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -16,6 +16,25 @@ require 'rails_helper'
 # separator handling; these specs cover the current 7.2 behavior any regressions
 # in path/query comparison would surface here.
 RSpec.describe ApplicationHelper, type: :helper do
+  describe '#release_info' do
+    after { Git.reset_memo! if Git.respond_to?(:reset_memo!) }
+
+    it 'renders a badge with the release when one is available' do
+      allow(Git).to receive(:release).and_return('v1.2.3+4')
+
+      rendered = helper.release_info
+
+      expect(rendered).to include('v1.2.3+4')
+      expect(rendered).to include('navbar-text')
+    end
+
+    it 'renders nothing when there is no release (e.g. cache missing or dev env)' do
+      allow(Git).to receive(:release).and_return(nil)
+
+      expect(helper.release_info).to be_nil
+    end
+  end
+
   describe '#menu_request_matches_generated_path?' do
     # Drive the private helper with a stubbed request path and params, mirroring
     # how a filtered menu link is compared against the current request.

--- a/spec/lib/util/git/release_resolver_spec.rb
+++ b/spec/lib/util/git/release_resolver_spec.rb
@@ -1,0 +1,178 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Git::ReleaseResolver do
+  let(:revision) { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+  let(:repo) { 'greenriver/hmis-warehouse' }
+
+  def stub_commits(shas)
+    stub_request(:get, "https://api.github.com/repos/#{repo}/commits").
+      with(query: { sha: revision, per_page: '50', page: '1' }).
+      to_return(
+        status: 200,
+        body: shas.map { |sha| { sha: sha } }.to_json,
+        headers: { 'Content-Type' => 'application/json' },
+      )
+  end
+
+  def stub_tags(pairs, page: 1)
+    stub_request(:get, "https://api.github.com/repos/#{repo}/tags").
+      with(query: { per_page: '100', page: page.to_s }).
+      to_return(
+        status: 200,
+        body: pairs.map { |name, sha| { name: name, commit: { sha: sha } } }.to_json,
+        headers: { 'Content-Type' => 'application/json' },
+      )
+  end
+
+  describe '.resolve' do
+    it 'returns ahead: 0 when the deployed commit is the tagged commit' do
+      stub_commits([revision, 'bbb', 'ccc'])
+      stub_tags([['staging-release-222.0', revision]])
+
+      expect(described_class.resolve(revision: revision)).
+        to eq(tag: 'staging-release-222.0', ahead: 0, revision: revision)
+    end
+
+    it 'looks back past hot-fix commits to the nearest ancestor tag' do
+      stub_commits([revision, 'hotfix2', 'hotfix1', 'tagged', 'older'])
+      stub_tags([['staging-release-221.0', 'tagged']])
+
+      expect(described_class.resolve(revision: revision)).
+        to eq(tag: 'staging-release-221.0', ahead: 3, revision: revision)
+    end
+
+    # Both orderings are required. With only one, dropping the nearest-wins guard in
+    # `resolve` degrades it to last-match-wins and the suite would stay green.
+    it 'picks the nearest tag regardless of the order tags are returned in (far, then near)' do
+      stub_commits([revision, 'near', 'far'])
+      stub_tags([['staging-release-100.0', 'far'], ['staging-release-222.0', 'near']])
+
+      expect(described_class.resolve(revision: revision)).
+        to include(tag: 'staging-release-222.0', ahead: 1)
+    end
+
+    it 'picks the nearest tag regardless of the order tags are returned in (near, then far)' do
+      stub_commits([revision, 'near', 'far'])
+      stub_tags([['staging-release-222.0', 'near'], ['staging-release-100.0', 'far']])
+
+      expect(described_class.resolve(revision: revision)).
+        to include(tag: 'staging-release-222.0', ahead: 1)
+    end
+
+    it 'ignores tags that are not ancestors of the deployed commit' do
+      stub_commits([revision, 'tagged'])
+      stub_tags([['staging-release-999.0', 'unrelated-branch-sha'], ['staging-release-221.0', 'tagged']])
+
+      expect(described_class.resolve(revision: revision)).
+        to include(tag: 'staging-release-221.0', ahead: 1)
+    end
+
+    it 'returns nil when no tag is an ancestor of the deployed commit' do
+      stub_commits([revision, 'bbb'])
+      stub_tags([['staging-release-999.0', 'unrelated']])
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+    end
+
+    it 'does not find a tag beyond the lookback window' do
+      stub_commits(50.times.map { |i| "c-#{i}" })
+      stub_tags([['staging-release-200.0', 'c-50']])
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+      expect(a_request(:get, "https://api.github.com/repos/#{repo}/commits").
+        with(query: hash_including(page: '2'))).not_to have_been_made
+    end
+
+    it 'requests a second page of tags when the first page is full' do
+      stub_commits([revision, 'tagged'])
+      stub_tags(100.times.map { |i| ["staging-release-#{i}.0", "tag-sha-#{i}"] })
+      stub_tags([['staging-release-200.0', 'tagged']], page: 2)
+
+      expect(described_class.resolve(revision: revision)).
+        to include(tag: 'staging-release-200.0', ahead: 1)
+      expect(a_request(:get, "https://api.github.com/repos/#{repo}/tags").
+        with(query: { per_page: '100', page: '3' })).not_to have_been_made
+    end
+
+    it 'does not request a second page of tags when the first comes back short' do
+      stub_commits([revision])
+      stub_tags([['staging-release-222.0', revision]])
+
+      described_class.resolve(revision: revision)
+
+      expect(a_request(:get, "https://api.github.com/repos/#{repo}/tags").
+        with(query: hash_including(page: '2'))).not_to have_been_made
+    end
+
+    it 'returns nil when the revision is blank' do
+      expect(described_class.resolve(revision: '')).to be_nil
+      expect(described_class.resolve(revision: nil)).to be_nil
+      expect(described_class.resolve(revision: 'unknown')).to be_nil
+    end
+
+    it 'returns nil on an API error status rather than raising' do
+      stub_request(:get, /https:\/\/api\.github\.com\/repos\//).to_return(status: 403, body: '{}')
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+    end
+
+    it 'returns nil on a network timeout rather than raising' do
+      stub_request(:get, /https:\/\/api\.github\.com\/repos\//).to_timeout
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+    end
+
+    it 'returns nil on unparseable JSON rather than raising' do
+      stub_request(:get, /https:\/\/api\.github\.com\/repos\//).
+        to_return(status: 200, body: 'not json', headers: { 'Content-Type' => 'application/json' })
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+    end
+
+    # A 200 whose body is an object rather than a list, which `get` rejects so the callers
+    # never try to iterate it.
+    it 'returns nil when the response body is not a list' do
+      stub_request(:get, /https:\/\/api\.github\.com\/repos\//).
+        to_return(status: 200, body: '{"message":"rate limited"}', headers: { 'Content-Type' => 'application/json' })
+
+      expect(described_class.resolve(revision: revision)).to be_nil
+    end
+  end
+
+  describe '.write_cache_file' do
+    let(:path) { Rails.root.join('tmp', "git_release_spec_#{SecureRandom.hex(4)}.json").to_s }
+
+    after { File.delete(path) if File.exist?(path) }
+
+    it 'writes the resolved payload as JSON and returns true' do
+      stub_commits([revision])
+      stub_tags([['staging-release-222.0', revision]])
+
+      expect(described_class.write_cache_file(revision: revision, path: path)).to be true
+      expect(JSON.parse(File.read(path))).
+        to eq('tag' => 'staging-release-222.0', 'ahead' => 0, 'revision' => revision)
+    end
+
+    it 'writes nothing and returns false when resolution fails' do
+      stub_request(:get, /https:\/\/api\.github\.com\/repos\//).to_return(status: 403, body: '{}')
+
+      expect(described_class.write_cache_file(revision: revision, path: path)).to be false
+      expect(File.exist?(path)).to be false
+    end
+
+    it 'returns false rather than raising when the path is not writable' do
+      stub_commits([revision])
+      stub_tags([['staging-release-222.0', revision]])
+
+      expect(described_class.write_cache_file(revision: revision, path: '/proc/nope/git_release.json')).to be false
+    end
+  end
+end

--- a/spec/lib/util/git/release_resolver_spec.rb
+++ b/spec/lib/util/git/release_resolver_spec.rb
@@ -9,6 +9,15 @@
 require 'rails_helper'
 
 RSpec.describe Git::ReleaseResolver do
+  # rails_helper leaves net connections allowed suite-wide. Block them for this file only,
+  # so a stub that stops matching fails here instead of quietly reaching api.github.com.
+  around do |example|
+    WebMock.disable_net_connect!(allow_localhost: true)
+    example.run
+  ensure
+    WebMock.allow_net_connect!
+  end
+
   let(:revision) { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
   let(:repo) { 'greenriver/boston-cas' }
 

--- a/spec/lib/util/git/release_resolver_spec.rb
+++ b/spec/lib/util/git/release_resolver_spec.rb
@@ -1,7 +1,7 @@
 ###
 # Copyright Green River Data Group, Inc.
 #
-# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
 ###
 
 # frozen_string_literal: true
@@ -10,7 +10,7 @@ require 'rails_helper'
 
 RSpec.describe Git::ReleaseResolver do
   let(:revision) { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
-  let(:repo) { 'greenriver/hmis-warehouse' }
+  let(:repo) { 'greenriver/boston-cas' }
 
   def stub_commits(shas)
     stub_request(:get, "https://api.github.com/repos/#{repo}/commits").

--- a/spec/lib/util/git_spec.rb
+++ b/spec/lib/util/git_spec.rb
@@ -1,0 +1,103 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/boston-cas/blob/stable/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers Git.release / Git.release_details, ported from hmis-warehouse.
+# These read the cache file written by Git::ReleaseResolver at container boot
+# (lib/util/git/release_resolver.rb) — this spec only exercises the reader side.
+RSpec.describe Git do
+  let(:cache_path) { Git::ReleaseResolver::CACHE_PATH }
+  let(:revision) { 'abc1234' }
+
+  before do
+    allow(Git).to receive(:revision).and_return(revision)
+    Git.reset_memo! if Git.respond_to?(:reset_memo!)
+  end
+
+  after do
+    Git.reset_memo! if Git.respond_to?(:reset_memo!)
+  end
+
+  def write_cache(tag:, ahead:, cache_revision: revision)
+    allow(File).to receive(:exist?).with(cache_path).and_return(true)
+    allow(File).to receive(:read).with(cache_path).and_return(
+      { tag: tag, ahead: ahead, revision: cache_revision }.to_json,
+    )
+  end
+
+  describe '.release' do
+    it 'returns nil in development regardless of cache contents' do
+      allow(Rails.env).to receive(:development?).and_return(true)
+      write_cache(tag: 'v1.2.3', ahead: 0)
+
+      expect(Git.release).to be_nil
+    end
+
+    it 'returns the bare tag when ahead is zero' do
+      write_cache(tag: 'v1.2.3', ahead: 0)
+
+      expect(Git.release).to eq('v1.2.3')
+    end
+
+    it 'returns "tag+N" when ahead of the tagged commit' do
+      write_cache(tag: 'v1.2.3', ahead: 4)
+
+      expect(Git.release).to eq('v1.2.3+4')
+    end
+
+    it 'coerces a string ahead count' do
+      write_cache(tag: 'v1.2.3', ahead: '4')
+
+      expect(Git.release).to eq('v1.2.3+4')
+    end
+
+    it 'returns nil when the cache file does not exist' do
+      allow(File).to receive(:exist?).with(cache_path).and_return(false)
+
+      expect(Git.release).to be_nil
+    end
+
+    it 'returns nil when the cache is for a different revision (stale deploy)' do
+      write_cache(tag: 'v1.2.3', ahead: 0, cache_revision: 'zzz9999')
+
+      expect(Git.release).to be_nil
+    end
+
+    it 'returns nil when the tag is empty' do
+      write_cache(tag: '', ahead: 0)
+
+      expect(Git.release).to be_nil
+    end
+
+    it 'returns nil when the cache file contains invalid JSON' do
+      allow(File).to receive(:exist?).with(cache_path).and_return(true)
+      allow(File).to receive(:read).with(cache_path).and_return('not json')
+
+      expect(Git.release).to be_nil
+    end
+
+    it 'memoizes release_details so the file is only read once per process' do
+      write_cache(tag: 'v1.2.3', ahead: 0)
+
+      Git.release
+      Git.release
+
+      expect(File).to have_received(:read).with(cache_path).once
+    end
+
+    it 'memoizes a nil result too (does not re-check File.exist? on every call)' do
+      allow(File).to receive(:exist?).with(cache_path).and_return(false)
+
+      Git.release
+      Git.release
+
+      expect(File).to have_received(:exist?).with(cache_path).once
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,9 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'deprecation_helper'
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting a release-X branch
- use a merge-commit or rebase strategy for PRs targeting the stable branch

## Description
[//]: # (Summarize changes and include links related issue. List any new dependencies)

Ports hmis-warehouse's release-tag display to boston-cas, so a deployed environment shows a human-readable release identifier instead of only a raw git SHA.

- `lib/util/git/release_resolver.rb` runs from `docker/app/entrypoint.sh` at container boot (web containers only), walks the deployed commit's ancestors against the GitHub API's `/commits` and `/tags` endpoints, and writes the nearest matching tag + how far ahead it is to `tmp/git_release.json`. It uses no Rails APIs, since it runs before the app boots.
- `Git.release`/`Git.release_details` (`lib/util/git.rb`) read that cache file at runtime, memoized per-process, and are invalidated if the cache's revision doesn't match the currently running one (e.g. a stale deploy).
- `SystemStatusController#details` now includes a `release` key alongside the existing `revision`/`branch` fields.
- `ApplicationHelper#release_info` renders a `navbar-text` badge (mirroring the existing `branch_info` pattern) and is wired into `_header_warnings.haml` next to the branch/revision badges, so it only appears where those are already shown.
- Added `webmock` to the test group to stub the GitHub API calls in `release_resolver_spec.rb`, matching hmis-warehouse's own test setup (`WebMock.allow_net_connect!` by default, per-example stubs for the calls under test).

## Type of change
[//]: # (e.g., Bug fix, New feature, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I have performed a self-review of my code
- [X] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have updated the documentation (or not applicable)
- [X] I have added spec tests (or not applicable)
- [ ] I have provided testing instructions in this PR or the related issue (or not applicable)
